### PR TITLE
perf(font): mono → display:optional + re-tighten CLS gate

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ const mono = localFont({
     { path: '../public/fonts/jetbrains-mono-700.woff2', weight: '700', style: 'normal' },
   ],
   variable: '--font-mono',
-  display: 'swap',
+  display: 'optional',
   preload: true,
 });
 

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -22,7 +22,7 @@
         "categories:seo": ["error", { "minScore": 1.0 }],
 
         "largest-contentful-paint": ["error", { "maxNumericValue": 1800 }],
-        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.05 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.05 }],
         "total-blocking-time": ["error", { "maxNumericValue": 200 }],
         "interactive": ["error", { "maxNumericValue": 2500 }],
 

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -22,7 +22,7 @@
         "categories:seo": ["error", { "minScore": 1.0 }],
 
         "largest-contentful-paint": ["error", { "maxNumericValue": 1800 }],
-        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.05 }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.05 }],
         "total-blocking-time": ["error", { "maxNumericValue": 200 }],
         "interactive": ["error", { "maxNumericValue": 2500 }],
 


### PR DESCRIPTION
## Summary

Switches `mono` font from `display: 'swap'` to `display: 'optional'`. **This does NOT fix the desktop CLS regression** (3 CI runs at 0.075-0.083 with the change — same range as without it). The original root-cause hypothesis (Arial unavailable on ubuntu runners → font swap → CLS) doesn't actually explain the measurement.

Shipping this anyway because the change is defensible on its own merits:
- `optional` is more aggressive than `swap`: browser commits to fallback within ~100ms instead of swapping later
- Eliminates any future regression if Arial ever becomes unavailable on the local dev machine (which today reports 4e-6 CLS)
- No downside (Lighthouse `font-display` audit still passes; system mono is a valid permanent fallback for rare slow-connection cases)

## What this PR does NOT do

- Does NOT fix the desktop CLS regression
- Does NOT close the BLOCKING CRITERION from `DECISIONS.md` 2026-05-19. CLS gate stays at `warn` (revert in this PR's second commit)

## Deeper investigation needed

The real CLS source needs to be found by extracting `layout-shift-elements` from the actual Lighthouse JSON output (not from a hypothesis). Suspects to verify:
- Vercel Analytics / Speed Insights script injection causing reflow
- Hero responsive dual-section (`.hero--desktop` + `.hero--mobile` both in DOM)
- IntersectionObserver-triggered animations
- Image without aspect-ratio reservation

Follow-up PR will land the actual fix once identified.

## Test Plan
- [ ] CI passes (CLS stays at warn so the gate doesn't fail on this PR)
- [ ] Confirm Lighthouse font-display audit still scores well with the new display setting