### PR TITLE
fix(rum): gate Vercel Analytics on VERCEL=1 — silences errors-in-console

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -370,8 +370,16 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
             "1" in any Vercel environment (prod/preview) and unset in local builds
             and CI. Mounting them outside Vercel logs SDK errors to the browser
             console (no token/origin), which trips Lighthouse's errors-in-console
-            audit. Gating here makes the audit pass everywhere except real prod,
-            where the SDK errors would mean a misconfigured deploy anyway. */}
+            audit. Gating here makes the audit pass in local + CI; on prod/preview
+            the SDK initializes normally with the Vercel-injected token.
+
+            Caveat: process.env.VERCEL is read at BUILD time, not runtime. If a
+            build artifact is produced outside Vercel and later deployed to a
+            Vercel runtime (a "prebuilt" deploy flow), the gate stays false and
+            the RUM scripts won't mount even though the app IS running on Vercel.
+            This project always builds inside Vercel (every deploy is a fresh
+            `next build` in the Vercel runtime), so the build-time gate is correct.
+            If a future change splits build + deploy, flip this to a runtime check. */}
         {process.env.VERCEL === '1' && (
           <>
             <Analytics />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -366,8 +366,18 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       <body suppressHydrationWarning>
         <Script src="/init.js" strategy="beforeInteractive" />
         {children}
-        <Analytics />
-        <SpeedInsights />
+        {/* Vercel RUM scripts only mount on Vercel deploys. process.env.VERCEL is
+            "1" in any Vercel environment (prod/preview) and unset in local builds
+            and CI. Mounting them outside Vercel logs SDK errors to the browser
+            console (no token/origin), which trips Lighthouse's errors-in-console
+            audit. Gating here makes the audit pass everywhere except real prod,
+            where the SDK errors would mean a misconfigured deploy anyway. */}
+        {process.env.VERCEL === '1' && (
+          <>
+            <Analytics />
+            <SpeedInsights />
+          </>
+        )}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

Closes the `errors-in-console` Lighthouse warning that's been tracked on the gate-patch ADR since 2026-05-19 (currently `warn` on desktop + mobile lighthouserc).

## Root cause

`@vercel/analytics/next` and `@vercel/speed-insights/next` mount unconditionally in `app/layout.tsx`. In environments without a Vercel project token + origin (local builds + CI's `pnpm start` preview server), the SDKs log errors to the browser console when they try to send beacons. Lighthouse's `errors-in-console` audit then scores 0.

## Fix

Gate the mount on `process.env.VERCEL === '1'` — the env var Vercel sets in production AND preview deploys. Unset in local dev and CI.

```tsx
{process.env.VERCEL === '1' && (
  <>
    <Analytics />
    <SpeedInsights />
  </>
)}
```

## Trade-off

CI's Lighthouse runs no longer see the RUM scripts, so they don't measure analytics-script weight against the bundle budget. Acceptable because:
- The SDK adds ~1.5KB gzipped; well within the existing 320KB client total budget
- Real prod deploys still mount the SDK normally (VERCEL=1 there)
- The gate now passes everywhere except a misconfigured prod deploy — which would be a legitimate signal

## Follow-up

Once this lands, the `errors-in-console` warn in `lighthouserc.json` and `lighthouserc.mobile.json` can be tightened back to `error`. That tightening lands in a separate small PR after this one merges (one change at a time keeps reverts clean).

## Test Plan
- [ ] CI build-and-gate desktop + mobile Lighthouse runs both green
- [ ] `pnpm vitest run` 202 passing locally (unchanged)
- [ ] No regression on prod deploy: Analytics + SpeedInsights still active (verify via DevTools Network on a Vercel preview after merge)