### PR TITLE
feat(e2e): Phase 2 — contact + ask error-path expansion (7 tests)

### DIFF
--- a/tests/e2e/ask.spec.ts
+++ b/tests/e2e/ask.spec.ts
@@ -1,36 +1,107 @@
 // tests/e2e/ask.spec.ts
 //
-// Phase 1 anchor tests: ask happy path + X-Request-Id header assertion.
-// Full surface (tests 2-6, 8: error states + privacy notice) ships in Phase 2.
+// Phase 1 anchor tests (1, 7): happy path + X-Request-Id header.
+// Phase 2 expansion (2-6): kill-switch, rate-limit, budget-exhausted, stream-error,
+//                          pre-stream-timeout. Test 8 (privacy notice) ships in Phase 3.
 
-import { expect, test } from '@playwright/test';
-import { installMockBackend } from './_helpers/mock-backend';
+import { expect, type Locator, type Page, test } from '@playwright/test';
+import { installMockBackend, type MockState } from './_helpers/mock-backend';
+
+async function setupAskPage(page: Page, state: MockState): Promise<void> {
+  await installMockBackend(page, state);
+  await page.goto('/');
+  // Wait for the Shell island to hydrate (shell form is present).
+  await page.waitForSelector('.shell__form', { state: 'visible' });
+}
+
+function getShellInput(page: Page): Locator {
+  return page.locator('.shell__form input[type="text"], .shell__form input:not([type])').first();
+}
+
+async function ask(page: Page, question: string): Promise<void> {
+  const shellInput = getShellInput(page);
+  await shellInput.fill(question);
+  await shellInput.press('Enter');
+}
 
 test.describe('ask / interactive shell', () => {
-  test.beforeEach(async ({ page }) => {
-    await installMockBackend(page, {
-      ask: 'happy',
-      log: 'accept',
-    });
-    await page.goto('/');
-    // Wait for the Shell island to hydrate (shell form is present).
-    await page.waitForSelector('.shell__form', { state: 'visible' });
-  });
-
   test('1 — happy path: type a question → canned answer renders in shell feed', async ({
     page,
   }) => {
-    // Type a question into the shell input.
-    const shellInput = page
-      .locator('.shell__form input[type="text"], .shell__form input:not([type])')
-      .first();
-    await shellInput.fill('Who is Erik?');
-    await shellInput.press('Enter');
+    await setupAskPage(page, { ask: 'happy', log: 'accept' });
+    await ask(page, 'Who is Erik?');
 
     // After submission the canned mock answer should appear in the feed.
     // The mock returns: "Erik is a Senior Full-Stack Engineer with 8+ years of experience."
     const feed = page.locator('.shell__feed');
     await expect(feed).toContainText('Erik is a Senior Full-Stack Engineer', { timeout: 10_000 });
+  });
+
+  test('2 — kill switch on: 503 surfaces "temporarily unavailable" message', async ({ page }) => {
+    // Mock returns 503 with { error: 'temporarily unavailable — email ... directly' }.
+    // InteractiveShell.streamQuestion reads data.error on !res.ok and renders it via
+    // an error line in the shell feed (kind: 'error', prefixed with "error: ").
+    await setupAskPage(page, { ask: 'kill-switch', log: 'accept' });
+    await ask(page, 'are you available?');
+
+    const errorLine = page.locator('.shell__feed .shell__line--error');
+    await expect(errorLine).toBeVisible({ timeout: 10_000 });
+    await expect(errorLine).toContainText('temporarily unavailable');
+  });
+
+  test('3 — rate-limit hit: 429 surfaces "try again in an hour"', async ({ page }) => {
+    // Mock returns 429 with { error: 'rate limit exceeded — try again in an hour' }.
+    await setupAskPage(page, { ask: 'rate-limit', log: 'accept' });
+    await ask(page, 'spammy question');
+
+    const errorLine = page.locator('.shell__feed .shell__line--error');
+    await expect(errorLine).toBeVisible({ timeout: 10_000 });
+    await expect(errorLine).toContainText('try again in an hour');
+  });
+
+  test('4 — budget exhausted: 503 surfaces budget message', async ({ page }) => {
+    // Mock returns 503 with { error: 'monthly budget exhausted — email ... directly' }.
+    // Same UI shape as kill-switch (both 503 + JSON error body), but distinct
+    // copy that the user actually sees.
+    await setupAskPage(page, { ask: 'budget-exhausted', log: 'accept' });
+    await ask(page, 'what is your stack?');
+
+    const errorLine = page.locator('.shell__feed .shell__line--error');
+    await expect(errorLine).toBeVisible({ timeout: 10_000 });
+    await expect(errorLine).toContainText('budget exhausted');
+  });
+
+  test('5 — stream error: STREAM_ERR_SENTINEL mid-stream renders an error line', async ({
+    page,
+  }) => {
+    // Mock streams the sentinel + "upstream error". The client splits the buffer
+    // at the sentinel: anything before becomes the output line, anything after
+    // becomes the error message. Here the sentinel arrives at byte 0 so only the
+    // error line should render.
+    await setupAskPage(page, { ask: 'stream-error', log: 'accept' });
+    await ask(page, 'tell me about your projects');
+
+    const errorLine = page.locator('.shell__feed .shell__line--error');
+    await expect(errorLine).toBeVisible({ timeout: 10_000 });
+    await expect(errorLine).toContainText('upstream error');
+  });
+
+  test('6 — pre-stream timeout: SDK rejects before SSE starts → error line, no crash', async ({
+    page,
+  }) => {
+    // Spec 1 fix: when Anthropic SDK times out before the first chunk, the route
+    // emits STREAM_ERR_SENTINEL + "Request Timeout" instead of leaking an
+    // unhandled rejection. The shell renders the timeout as a normal error line.
+    await setupAskPage(page, { ask: 'pre-stream-timeout', log: 'accept' });
+    await ask(page, 'slow question');
+
+    const errorLine = page.locator('.shell__feed .shell__line--error');
+    await expect(errorLine).toBeVisible({ timeout: 10_000 });
+    await expect(errorLine).toContainText('Request Timeout');
+
+    // No unhandled crash: the shell input must be re-enabled after the failure
+    // so the user can retry without reloading.
+    await expect(getShellInput(page)).toBeEnabled();
   });
 
   test('7 — X-Request-Id header is present and non-empty in /api/ask response', async ({
@@ -45,11 +116,8 @@ test.describe('ask / interactive shell', () => {
       }
     });
 
-    const shellInput = page
-      .locator('.shell__form input[type="text"], .shell__form input:not([type])')
-      .first();
-    await shellInput.fill('Test question for header check');
-    await shellInput.press('Enter');
+    await setupAskPage(page, { ask: 'happy', log: 'accept' });
+    await ask(page, 'Test question for header check');
 
     // Wait for the response to arrive.
     await page.waitForFunction(() => document.querySelector('.shell__line--output') !== null, {

--- a/tests/e2e/ask.spec.ts
+++ b/tests/e2e/ask.spec.ts
@@ -104,10 +104,14 @@ test.describe('ask / interactive shell', () => {
     await expect(getShellInput(page)).toBeEnabled();
   });
 
-  test('7 — X-Request-Id header is present and non-empty in /api/ask response', async ({
+  test('7 — X-Request-Id header is the deterministic value from the happy mock', async ({
     page,
   }) => {
-    // Intercept the /api/ask response to capture headers.
+    // Single source of truth: the `ask: 'happy'` mock in mock-backend.ts owns
+    // the X-Request-Id contract (deterministic value 'test-request-id-abc123').
+    // We deliberately do NOT register a standalone page.route('**/api/ask', ...)
+    // here — a second handler would race the mock-backend registration and the
+    // ordering would silently determine which response wins.
     let requestId: string | null = null;
 
     page.on('response', (resp) => {
@@ -124,7 +128,9 @@ test.describe('ask / interactive shell', () => {
       timeout: 10_000,
     });
 
-    expect(requestId).not.toBeNull();
-    expect(requestId).not.toBe('');
+    // Assert the exact value emitted by the happy mock. Pinning (vs. just
+    // non-empty) makes any future drift in mock-backend.ts an intentional,
+    // reviewable change instead of silently passing through.
+    expect(requestId).toBe('test-request-id-abc123');
   });
 });

--- a/tests/e2e/contact.spec.ts
+++ b/tests/e2e/contact.spec.ts
@@ -1,33 +1,32 @@
 // tests/e2e/contact.spec.ts
 //
-// Phase 1 anchor tests: contact form happy path + blank-submit validation.
-// Full surface (tests 3-4: rate-limit, server-error) ships in Phase 2.
+// Phase 1 anchor tests (1-2): happy path + blank-submit validation.
+// Phase 2 expansion (3-4): rate-limit + server-error.
 // Test 5 (honeypot trip) was removed — the honeypot field was planned but never built.
 
-import { expect, test } from '@playwright/test';
-import { installMockBackend } from './_helpers/mock-backend';
+import { expect, type Page, test } from '@playwright/test';
+import { installMockBackend, type MockState } from './_helpers/mock-backend';
+
+async function setupContactPage(page: Page, state: MockState): Promise<void> {
+  // Install mocks before navigation so no real /api/* call escapes.
+  await installMockBackend(page, state);
+  await page.goto('/');
+  // Scroll the contact section into view. It is below the fold.
+  await page.locator('#sec-contact').scrollIntoViewIfNeeded();
+  // Wait for the lazy-loaded ContactForm island to hydrate.
+  await page.waitForSelector('form.contact', { state: 'visible' });
+}
+
+async function fillValidForm(page: Page): Promise<void> {
+  await page.locator('form.contact input[autocomplete="name"]').fill('Test User');
+  await page.locator('form.contact input[type="email"]').fill('test@example.com');
+  await page.locator('form.contact textarea').fill('Hello, this is a test message long enough.');
+}
 
 test.describe('contact form', () => {
-  test.beforeEach(async ({ page }) => {
-    // Install mocks before navigation so no real /api/* call escapes.
-    await installMockBackend(page, {
-      contact: 'happy',
-      log: 'accept',
-    });
-    await page.goto('/');
-    // Scroll the contact section into view. It is below the fold.
-    await page.locator('#sec-contact').scrollIntoViewIfNeeded();
-    // Wait for the lazy-loaded ContactForm island to hydrate.
-    await page.waitForSelector('form.contact', { state: 'visible' });
-  });
-
   test('1 — happy path: fill all fields and submit → success state', async ({ page }) => {
-    // Fill the name field (first input inside form.contact).
-    await page.locator('form.contact input[autocomplete="name"]').fill('Test User');
-    // Fill the email field.
-    await page.locator('form.contact input[type="email"]').fill('test@example.com');
-    // Fill the message textarea (minLength=10 required).
-    await page.locator('form.contact textarea').fill('Hello, this is a test message long enough.');
+    await setupContactPage(page, { contact: 'happy', log: 'accept' });
+    await fillValidForm(page);
 
     // Submit the form.
     await page.locator('form.contact button[type="submit"]').click();
@@ -42,6 +41,7 @@ test.describe('contact form', () => {
   test('2 — validation: blank submit shows field-level error (browser native)', async ({
     page,
   }) => {
+    await setupContactPage(page, { contact: 'happy', log: 'accept' });
     // Click submit without filling any fields. The browser prevents submission
     // via HTML5 validation (required attributes). No fetch call reaches /api/contact.
     await page.locator('form.contact button[type="submit"]').click();
@@ -54,5 +54,45 @@ test.describe('contact form', () => {
     // Playwright exposes :invalid pseudo-class via evaluate.
     const isInvalid = await nameInput.evaluate((el) => !(el as HTMLInputElement).validity.valid);
     expect(isInvalid).toBe(true);
+  });
+
+  test('3 — rate-limited: 429 response surfaces "try again" message to the user', async ({
+    page,
+  }) => {
+    // Mock returns 429 with { error: 'too many requests — try again in 10 minutes' }.
+    // ContactForm reads data.error and renders it inside .contact__error[role="alert"].
+    await setupContactPage(page, { contact: 'rate-limit', log: 'accept' });
+    await fillValidForm(page);
+
+    await page.locator('form.contact button[type="submit"]').click();
+
+    // The form stays mounted (no success replacement) — the error renders inside it.
+    await expect(page.locator('form.contact')).toBeVisible();
+    const errorEl = page.locator('form.contact .contact__error[role="alert"]');
+    await expect(errorEl).toBeVisible({ timeout: 5_000 });
+    // Surfaces the upstream "try again" hint with retry-after window (10 minutes).
+    await expect(errorEl).toContainText('try again');
+    await expect(errorEl).toContainText('10 minutes');
+  });
+
+  test('4 — server-error: 502 response renders graceful error UI, no crash', async ({ page }) => {
+    // Mock returns 502 with { error: 'storage unavailable — try again' }, mirroring
+    // the real route's KV-failure branch. The page must stay interactive — the form
+    // remains mounted and the error renders inside it via role="alert".
+    await setupContactPage(page, { contact: 'server-error', log: 'accept' });
+    await fillValidForm(page);
+
+    await page.locator('form.contact button[type="submit"]').click();
+
+    // Form stays in place — no unhandled crash, no success state.
+    await expect(page.locator('form.contact')).toBeVisible();
+    await expect(page.locator('.contact.contact--success')).toHaveCount(0);
+    const errorEl = page.locator('form.contact .contact__error[role="alert"]');
+    await expect(errorEl).toBeVisible({ timeout: 5_000 });
+    await expect(errorEl).toContainText('storage unavailable');
+
+    // Sanity: page is still interactive — submit button is re-enabled
+    // (status returns to 'error', no longer 'submitting').
+    await expect(page.locator('form.contact button[type="submit"]')).toBeEnabled();
   });
 });

--- a/tests/e2e/contact.spec.ts
+++ b/tests/e2e/contact.spec.ts
@@ -68,7 +68,9 @@ test.describe('contact form', () => {
 
     // The form stays mounted (no success replacement) — the error renders inside it.
     await expect(page.locator('form.contact')).toBeVisible();
-    const errorEl = page.locator('form.contact .contact__error[role="alert"]');
+    // Pure semantic selector: scoped to the form, identified by ARIA role only.
+    // Survives CSS refactors (e.g. renaming `.contact__error`) without churn.
+    const errorEl = page.locator('form.contact').getByRole('alert');
     await expect(errorEl).toBeVisible({ timeout: 5_000 });
     // Surfaces the upstream "try again" hint with retry-after window (10 minutes).
     await expect(errorEl).toContainText('try again');
@@ -87,7 +89,9 @@ test.describe('contact form', () => {
     // Form stays in place — no unhandled crash, no success state.
     await expect(page.locator('form.contact')).toBeVisible();
     await expect(page.locator('.contact.contact--success')).toHaveCount(0);
-    const errorEl = page.locator('form.contact .contact__error[role="alert"]');
+    // Pure semantic selector: scoped to the form, identified by ARIA role only.
+    // Survives CSS refactors (e.g. renaming `.contact__error`) without churn.
+    const errorEl = page.locator('form.contact').getByRole('alert');
     await expect(errorEl).toBeVisible({ timeout: 5_000 });
     await expect(errorEl).toContainText('storage unavailable');
 


### PR DESCRIPTION
## Summary

Extends the Phase 1 anchor (PR #18) with the error-path coverage from spec §6 + §10. Adds 7 new tests across `contact.spec.ts` (+2) and `ask.spec.ts` (+5), all exercising existing mock states from Phase 1 `mock-backend.ts` — zero helper churn.

### contact.spec.ts (tests 3-4)
- **3 — rate-limit**: backend returns 429 → `role="alert"` surfaces the upstream retry-after copy ("try again in 10 minutes")
- **4 — server-error**: backend returns 502 (mirrors real KV-failure branch) → form stays mounted, error renders, submit button re-enabled (no unhandled crash)

### ask.spec.ts (tests 2-6)
- **2 — kill switch**: 503 surfaces "temporarily unavailable" in the shell feed error line
- **3 — rate-limit**: 429 surfaces "try again in an hour"
- **4 — budget exhausted**: 503 surfaces "budget exhausted"
- **5 — stream error**: `STREAM_ERR_SENTINEL + msg` mid-stream renders an error line ("upstream error")
- **6 — pre-stream timeout**: backend rejects before SSE starts → "Request Timeout" error line + shell input re-enabled. This is the Spec 1 regression guard — without it, the route used to leak an unhandled rejection.

### Refactor

Replaced the shared `test.beforeEach` with per-test setup helpers (`setupContactPage` / `setupAskPage` / `fillValidForm` / `ask`) so each test owns its mock state explicitly. Required because each new test wants a different `MockState`.

### Test count delta (chromium project)

| Spec | Before | After |
|---|---|---|
| `contact.spec.ts` | 2 | 4 |
| `ask.spec.ts` | 2 | 7 |
| **contact + ask combined** | **4** | **11** |

Across the 4-project matrix (chromium-desktop / chromium-mobile / webkit-desktop / webkit-mobile): 16 -> 44 runs in the `e2e-full` job.

### References

- Spec: `docs/superpowers/specs/2026-05-19-e2e-tests-design.md` §6 + §10
- Phase 1 anchor: #18
- No `mock-backend.ts` extensions — all required states (`ask: 'kill-switch' | 'rate-limit' | 'budget-exhausted' | 'stream-error' | 'pre-stream-timeout'`, `contact: 'rate-limit' | 'server-error'`) were already shipped in Phase 1.

## Test plan

- [x] `pnpm check` — clean (pre-existing copilot warnings unrelated)
- [x] `pnpm typecheck` — clean
- [x] `pnpm validate-content` — 18/18 passed
- [x] `pnpm test` — 202/202 passed
- [x] `pnpm playwright test --project=chromium tests/e2e/contact.spec.ts tests/e2e/ask.spec.ts` — 11/11 passed
- [x] `pnpm playwright test --project=chromium-mobile tests/e2e/contact.spec.ts tests/e2e/ask.spec.ts` — 11/11 passed (mobile selectors verified)
- [ ] CI `e2e-full` matrix (4 projects) — runs on PR

## Out of scope (next phases)

- Phase 3: ask test 8 (privacy notice) + visual tests 3-5
- Phase 4: cross-cutting tests 1-4
- Phase 5: promote `e2e-full` to required