### PR TITLE
fix(config): remove turbopack.resolveAlias — Vercel CLI 54.3.0 modifyConfig crash

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,7 +202,6 @@ lib/
   lighthouse-scores.ts         # PSI API fetcher (cached daily)
   log.ts                       # pino wrapper (text dev / JSON prod)
   motion.ts                    # readMotion / applyMotion (body data-attr)
-  polyfills-noop.ts            # no-op stub (postinstall strips Next polyfills)
   rate-limit.ts                # Upstash sliding-window + budget reserve/settle
   stream-protocol.ts           # NUL-byte error sentinel + parseStreamChunk buffer parser
   ua.ts                        # UA-based device detection (headers())

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2,6 +2,10 @@
 
 ADR-lite running log. One bullet per decision · date · reversibility note.
 
+## 2026-05-22 — `turbopack.resolveAlias` removed from next.config.ts
+
+- **2026-05-22** · **`turbopack.resolveAlias` removed from `next.config.ts`.** Vercel CLI 54.3.0 introduced a `modifyConfig` crash (`TypeError: The "path" argument must be of type string. Received undefined`, `ERR_INVALID_ARG_TYPE`) when processing `turbopack.resolveAlias` in production builds. The alias only applied to Turbopack dev builds; `scripts/strip-next-polyfills.mjs` postinstall was always the sole polyfill-stripping mechanism for webpack production builds. `lib/polyfills-noop.ts` (the alias target) deleted as unreferenced. _Reversible: re-add `turbopack: { resolveAlias: { 'next/dist/build/polyfills/polyfill-module': path.resolve('./lib/polyfills-noop.ts') } }` to `next.config.ts` if a future Vercel CLI fixes `modifyConfig`._
+
 ## 2026-05-22 — `ai-eval` CI job flipped to required
 
 - **2026-05-22** · **`ai-eval` promoted from non-blocking (`continue-on-error: true`) to a required status check on `main`.** The job runs `scripts/ask-eval.ts` — an LLM-judge eval over the `/api/ask` route scoring correctness (target ≥ 0.90) and jailbreak resistance (target = 1.0). It was shipped non-blocking in PR #34 to collect baseline data before gating merges (LLM-judge scoring is non-deterministic; premature gating risks false reds). After 6 green CI runs on `main` since P1 merged (2026-05-21 → 2026-05-22), the floor is stable. Changes: (a) removed `continue-on-error: true` from `.github/workflows/ci.yml`; (b) added `ai-eval` to `main`'s branch-protection required-status-checks list via `gh api -X PUT repos/erikunha/portfolio/branches/main/protection`. _Reversible: restore `continue-on-error: true` in `ci.yml` and remove `ai-eval` from branch-protection via the same `gh api -X PUT repos/erikunha/portfolio/branches/main/protection` call._

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,7 +4,7 @@ ADR-lite running log. One bullet per decision · date · reversibility note.
 
 ## 2026-05-22 — `turbopack.resolveAlias` removed from next.config.ts
 
-- **2026-05-22** · **`turbopack.resolveAlias` removed from `next.config.ts`.** Vercel CLI 54.3.0 introduced a `modifyConfig` crash (`TypeError: The "path" argument must be of type string. Received undefined`, `ERR_INVALID_ARG_TYPE`) when processing `turbopack.resolveAlias` in production builds. The alias only applied to Turbopack dev builds; `scripts/strip-next-polyfills.mjs` postinstall was always the sole polyfill-stripping mechanism for webpack production builds. `lib/polyfills-noop.ts` (the alias target) deleted as unreferenced. _Reversible: re-add `turbopack: { resolveAlias: { 'next/dist/build/polyfills/polyfill-module': path.resolve('./lib/polyfills-noop.ts') } }` to `next.config.ts` if a future Vercel CLI fixes `modifyConfig`._
+- **2026-05-22** · **`turbopack.resolveAlias` removed from `next.config.ts`.** Vercel CLI 54.3.0 introduced a `modifyConfig` crash (`TypeError: The "path" argument must be of type string. Received undefined`, `ERR_INVALID_ARG_TYPE`) when processing `turbopack.resolveAlias` in production builds. The alias only applied to Turbopack dev builds; `scripts/strip-next-polyfills.mjs` postinstall was always the sole polyfill-stripping mechanism for webpack production builds. `lib/polyfills-noop.ts` (the alias target) deleted as unreferenced. _Reversible: restore `lib/polyfills-noop.ts`, add `import path from 'node:path'` back to `next.config.ts`, and re-add `turbopack: { resolveAlias: { 'next/dist/build/polyfills/polyfill-module': path.resolve('./lib/polyfills-noop.ts') } }` if a future Vercel CLI fixes `modifyConfig`._
 
 ## 2026-05-22 — `ai-eval` CI job flipped to required
 

--- a/lib/polyfills-noop.ts
+++ b/lib/polyfills-noop.ts
@@ -1,5 +1,0 @@
-// All APIs patched by Next.js polyfill-module (Array.at, Object.hasOwn, flatMap,
-// Object.fromEntries, String trimStart/trimEnd, URL.canParse, Promise.finally)
-// are Baseline 2022 and supported by every browser in our browserslist target
-// (Chrome 93+, Edge 93+, Firefox 92+, Safari 15.4+). No polyfills needed.
-export {};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import withBundleAnalyzer from '@next/bundle-analyzer';
 import type { NextConfig } from 'next';
 
@@ -7,11 +6,6 @@ const analyze = withBundleAnalyzer({ enabled: process.env.ANALYZE === 'true' });
 const nextConfig: NextConfig = {
   cacheComponents: true,
   typedRoutes: true,
-  turbopack: {
-    resolveAlias: {
-      'next/dist/build/polyfills/polyfill-module': path.resolve('./lib/polyfills-noop.ts'),
-    },
-  },
   headers: async () => [
     {
       source: '/(.*)',

--- a/scripts/strip-next-polyfills.mjs
+++ b/scripts/strip-next-polyfills.mjs
@@ -9,14 +9,11 @@
  * Practices). Turbopack resolveAlias cannot intercept relative requires
  * inside node_modules, so postinstall overwrite is the only clean hook.
  *
- * Verification (2026-05-21): `next.config.ts` has `turbopack.resolveAlias`
- * pointing polyfill-module to `lib/polyfills-noop.ts`, but this only applies
- * to Turbopack builds (dev mode). The webpack production bundle still contains
- * the guard patterns (Array.prototype.at, Object.hasOwn, flatMap, fromEntries,
- * trimStart, URL.canParse) — confirmed by grepping .next/static/chunks/ after
- * `pnpm build` which returned 32 matches including if(!x.prototype.method)
- * guard assignments. This postinstall script remains the only mechanism that
- * strips polyfills from the webpack production build. See DECISIONS.md.
+ * Update (2026-05-22): `turbopack.resolveAlias` was removed from `next.config.ts`
+ * because Vercel CLI 54.3.0 `modifyConfig` crashes (ERR_INVALID_ARG_TYPE) when
+ * processing `resolveAlias` entries in production builds. The alias only ever
+ * applied to Turbopack dev builds anyway — this postinstall script is the sole
+ * mechanism stripping polyfills from webpack production builds. See DECISIONS.md.
  *
  * Safe to re-run: writes a fixed string, idempotent.
  */


### PR DESCRIPTION
## Summary

- Vercel CLI 54.3.0 introduced a `modifyConfig` crash (`TypeError: The "path" argument must be of type string. Received undefined`, `ERR_INVALID_ARG_TYPE`) when processing `turbopack.resolveAlias` in production builds
- The alias only ever applied to Turbopack dev builds — `scripts/strip-next-polyfills.mjs` postinstall was always the sole polyfill-stripping mechanism for webpack production builds
- Remove `turbopack: { resolveAlias: {...} }` and the now-unused `path` import from `next.config.ts`
- Delete `lib/polyfills-noop.ts` (now unreferenced)
- Update stale comment in `strip-next-polyfills.mjs` and add `DECISIONS.md` entry

## Test plan

- [ ] CI `build-and-gate` passes (no `modifyConfig` crash)
- [ ] Vercel preview build succeeds
- [ ] `pnpm build` local still passes
- [ ] `strip-next-polyfills.mjs` postinstall still runs and strips polyfills in both dev and prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)