### PR TITLE
fix(rate-limit): raise monthly token budget to 3M tokens (~$5/month)

### DIFF
--- a/__tests__/budget-cap.test.ts
+++ b/__tests__/budget-cap.test.ts
@@ -78,9 +78,9 @@ describe('budget reservation pattern', () => {
     expect(counter.value).toBe(INPUT_RESERVATION + 512);
   });
 
-  it('rejects and refunds the reservation when it would cross the 400k cap', async () => {
+  it('rejects and refunds the reservation when it would cross the 3M cap', async () => {
     // Place the counter 1k away from the cap so any reservation > 1k crosses.
-    counter.value = 399_000;
+    counter.value = 2_999_000;
     const { reserveBudget } = await import('@/lib/rate-limit');
     const result = await reserveBudget(512);
     expect(result.allowed).toBe(false);

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -91,7 +91,8 @@ export function getClientIp(req: import('next/server').NextRequest): string {
 
 // Monthly token budget — 3,000,000 tokens ≈ $5 blended Haiku 4.5 pricing.
 // Blended rate: 77% input × $0.80/MTok + 23% output × $4.00/MTok ≈ $1.54/MTok.
-// At ~2,200 tokens/request that's ~1,350 requests before the cap.
+// reserveBudget() reserves RESERVED_INPUT_TOKENS (2,200) + maxOutputTokens (512) = ~2,700
+// tokens per request, so the cap allows ~1,100 requests before it exhausts.
 // Hard cap at 100%; warn at 80%.
 const MONTHLY_TOKEN_BUDGET = 3_000_000;
 const BUDGET_WINDOW_S = 60 * 60 * 24 * 32;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -89,9 +89,11 @@ export function getClientIp(req: import('next/server').NextRequest): string {
   );
 }
 
-// Monthly token budget — 400,000 tokens ≈ $0.40 at Haiku input pricing.
+// Monthly token budget — 3,000,000 tokens ≈ $5 blended Haiku 4.5 pricing.
+// Blended rate: 77% input × $0.80/MTok + 23% output × $4.00/MTok ≈ $1.54/MTok.
+// At ~2,200 tokens/request that's ~1,350 requests before the cap.
 // Hard cap at 100%; warn at 80%.
-const MONTHLY_TOKEN_BUDGET = 400_000;
+const MONTHLY_TOKEN_BUDGET = 3_000_000;
 const BUDGET_WINDOW_S = 60 * 60 * 24 * 32;
 
 // Reservation pattern constants. Worst-case input tokens cover:


### PR DESCRIPTION
## Summary

- Raises \`MONTHLY_TOKEN_BUDGET\` from 400,000 to 3,000,000 tokens in \`lib/rate-limit.ts\`
- Updates the budget-cap test to validate the rejection threshold against the new 3M cap
- Resets the Redis counter for May 2026 (done out-of-band via Upstash REST API)

**Pricing basis:** Haiku 4.5 blended rate = 77% input x \$0.80/MTok + 23% output x \$4.00/MTok ~= \$1.54/MTok. \`reserveBudget()\` reserves RESERVED_INPUT_TOKENS (2,200) + maxOutputTokens (512) = ~2,700 tokens/request, giving ~1,100 requests before the monthly cap.

## Test plan

- [x] \`pnpm test __tests__/budget-cap.test.ts\` — all 5 reservation-pattern tests pass
- [x] Redis counter reset to 0 (interactive shell unblocked immediately)
- [ ] Verify shell responds after deploy to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)