### PR TITLE
chore(quality): P3 quick wins — sentinel dedup + rgba lint detection

### DIFF
--- a/scripts/lint-no-magic-values.allowlist.json
+++ b/scripts/lint-no-magic-values.allowlist.json
@@ -196,6 +196,67 @@
     },
     { "value": "840ms", "reason": "footer sd-halt-hint-reveal delay — 660ms + 180ms stagger" }
   ],
+  "color-functions": [
+    { "value": "rgba(0, 0, 0, 0)", "reason": "transparent black — gradient endpoint" },
+    { "value": "rgba(0, 0, 0, 0.38)", "reason": "vignette overlay — CRT corner darkening" },
+    {
+      "value": "rgba(0, 0, 0, 0.45)",
+      "reason": "CRT scanline pixel stop — exact opacity required"
+    },
+    {
+      "value": "rgba(0, 0, 0, 0.55)",
+      "reason": "module backdrop scrim — no semantic overlay token"
+    },
+    { "value": "rgba(0, 0, 0, 0.6)", "reason": "dialog/overlay scrim" },
+    { "value": "rgba(0, 0, 0, 0.85)", "reason": "heavy scrim — near-opaque backdrop" },
+    { "value": "rgba(0, 0, 0, 0.92)", "reason": "dock backdrop — near-black translucent surface" },
+    {
+      "value": "rgba(0, 80, 20, 0.12)",
+      "reason": "CRT phosphor glow radial — dark green ambient, no token"
+    },
+    {
+      "value": "rgba(0, 255, 0, 0.06)",
+      "reason": "CRT RGB sub-pixel green channel — exact geometry required"
+    },
+    {
+      "value": "rgba(0, 255, 65, 0.015)",
+      "reason": "signal-green opacity variant — hairline glow"
+    },
+    {
+      "value": "rgba(0, 255, 65, 0.02)",
+      "reason": "signal-green opacity variant — barely-visible tint"
+    },
+    { "value": "rgba(0, 255, 65, 0.025)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.03)", "reason": "signal-green opacity variant — subtle tint" },
+    {
+      "value": "rgba(0, 255, 65, 0.04)",
+      "reason": "signal-green opacity variant — hover/focus surface"
+    },
+    { "value": "rgba(0, 255, 65, 0.06)", "reason": "signal-green opacity variant — light surface" },
+    { "value": "rgba(0, 255, 65, 0.1)", "reason": "signal-green opacity variant" },
+    {
+      "value": "rgba(0, 255, 65, 0.12)",
+      "reason": "signal-green opacity variant — dock highlight"
+    },
+    { "value": "rgba(0, 255, 65, 0.15)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.18)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.25)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.3)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.35)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.4)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.45)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.5)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.55)", "reason": "signal-green opacity variant" },
+    { "value": "rgba(0, 255, 65, 0.6)", "reason": "signal-green opacity variant" },
+    {
+      "value": "rgba(0, 0, 255, 0.06)",
+      "reason": "CRT RGB sub-pixel blue channel — exact geometry required"
+    },
+    {
+      "value": "rgba(255, 0, 0, 0.06)",
+      "reason": "CRT RGB sub-pixel red channel — exact geometry required"
+    }
+  ],
   "z-index-values": [
     "0",
     "1",

--- a/scripts/lint-no-magic-values.mjs
+++ b/scripts/lint-no-magic-values.mjs
@@ -64,7 +64,7 @@ const checks = [
   },
   // rgba / rgb / hsl color function calls
   {
-    pattern: /\b(?:rgba?|hsla?)\s*\([^)]*\)/g,
+    pattern: /\b(?:rgba?|hsla?)\s*\([^)]*\)/gi,
     extract: (m) => m.replace(/\s+/g, ' ').trim(),
     filter: (m) => !allowedColorFunctions.has(m),
     message: (m) =>

--- a/scripts/lint-no-magic-values.mjs
+++ b/scripts/lint-no-magic-values.mjs
@@ -23,6 +23,7 @@ const allowedDurations = new Set(allowlist['duration-values'].map((e) => e.value
 const allowedZIndex = new Set(
   allowlist['z-index-values'].map((e) => (typeof e === 'string' ? e : e.value)),
 );
+const allowedColorFunctions = new Set((allowlist['color-functions'] ?? []).map((e) => e.value));
 
 /**
  * Strip CSS block comments from content so we never flag values inside them.
@@ -60,6 +61,14 @@ const checks = [
     extract: (m) => m,
     filter: (m) => !allowedHex.has(m),
     message: (m) => `hardcoded hex color ${m} — use a --ds-color-* token or add to allowlist`,
+  },
+  // rgba / rgb / hsl color function calls
+  {
+    pattern: /\b(?:rgba?|hsla?)\s*\([^)]*\)/g,
+    extract: (m) => m.replace(/\s+/g, ' ').trim(),
+    filter: (m) => !allowedColorFunctions.has(m),
+    message: (m) =>
+      `hardcoded color function ${m} — use a --ds-color-* token or add to allowlist with a reason`,
   },
   // Raw ms durations
   {

--- a/scripts/lint-no-magic-values.mjs
+++ b/scripts/lint-no-magic-values.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Rejects hardcoded magic values in .module.css: hex colors, non-token px,
-// hardcoded ms/s durations, raw z-index integers.
+// Rejects hardcoded magic values in .module.css: hex colors, color function literals
+// (rgba/rgb/hsl/hsla), non-token px, hardcoded ms/s durations, raw z-index integers.
 //
 // Intentionally does NOT flag:
 //   - Values inside CSS comments (/* ... */)

--- a/tests/e2e/_helpers/mock-backend.ts
+++ b/tests/e2e/_helpers/mock-backend.ts
@@ -13,6 +13,7 @@
 //     every UI test from having to wire `log: 'accept'` explicitly.
 
 import type { Page } from '@playwright/test';
+import { STREAM_ERR_SENTINEL } from '../../../lib/stream-protocol';
 
 export type MockState = {
   ask?:
@@ -26,10 +27,6 @@ export type MockState = {
   log?: 'accept' | 'rate-limit' | 'storage-unavailable';
   forget?: 'happy' | 'not-found';
 };
-
-// STREAM_ERR_SENTINEL matches lib/stream-protocol.ts. Duplicated here so the
-// helper has zero runtime dependency on the Next.js source tree.
-const STREAM_ERR_SENTINEL = '\x00ERR:';
 
 export async function installMockBackend(page: Page, state: MockState = {}): Promise<void> {
   // --- /api/ask ---


### PR DESCRIPTION
## Summary

- **STREAM_ERR_SENTINEL dedup (P3-4):** The sentinel string was duplicated in `tests/e2e/_helpers/mock-backend.ts`; it now imports from `lib/stream-protocol.ts` (the source of truth). Single source of truth, no behavior change.
- **rgba/color-function leak detection (P3-5):** `scripts/lint-no-magic-values.mjs` had no coverage for `rgba()`, `rgb()`, `hsl()`, and `hsla()` color function literals in CSS. Added detection with a 29-entry allowlist that documents every existing usage explicitly.
- **P3-6 deferred:** `noPropertyAccessFromIndexSignature` produces 140+ violations from `process.env.*` access patterns across the codebase; scoped to a standalone PR to keep this one reviewable.

## Type of change

- [ ] `feat` — new functionality
- [ ] `fix` — bug fix
- [x] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes — 85 test files, 565 tests, all green
- [x] New behaviour covered by tests — the sentinel import is exercised by existing E2E helper tests; the lint gate is self-validating (runs against the codebase on every `pnpm ci:local`)

## Visual changes

No UI changes in this PR.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — this PR adds detection for them, not new usages
- [x] No `use client` added without necessity (RSC drift) — no client components touched
- [x] Bundle size impact assessed (`pnpm bundle-check`) — no runtime code changed; sentinel import is test-only, lint script is build-tooling only
- [x] A11y impact considered (axe-core will gate in CI) — no markup or interactive elements changed
- [x] ADR added to `DECISIONS.md` if this changes architecture — no architectural change; lint gate extension is an incremental enforcement improvement