### PR TITLE
chore(ci): P3 tooling -- shared CSS scanner + parallel quality CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     concurrency:
       group: typecheck-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
-# Required jobs for branch protection: quality, test, build, performance,
+# Required jobs for branch protection: quality-fast, typecheck, test, build, performance,
 # e2e-functional, e2e-visual-chromium, ai-eval.
 # e2e-visual-webkit is intentionally NOT required (webkit pixel rendering variance).
 # vercel-preview is intentionally NOT required (informational only).
 # Manual step: add "CodeQL / Analyze (javascript-typescript)" to required checks in GitHub Settings.
+# Manual step (post-merge): in GitHub Settings → Branches → main → Required status checks,
+# replace "quality" with "quality-fast" AND "typecheck".
 
 on:
   pull_request:
@@ -21,20 +23,20 @@ on:
 
 # Top-level cancel-in-progress is false: a push to main must not cancel the
 # slower visual/e2e jobs still running from the previous commit.
-# Fast jobs (quality, test, build) use per-job concurrency groups instead.
+# Fast jobs (quality-fast, typecheck, test, build) use per-job concurrency groups instead.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  quality:
+  quality-fast:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     timeout-minutes: 8
     concurrency:
-      group: quality-${{ github.ref }}
+      group: quality-fast-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6
@@ -64,9 +66,6 @@ jobs:
 
       - name: Biome check
         run: pnpm biome ci .
-
-      - name: Type check
-        run: pnpm tsc --noEmit
 
       - name: Validate content
         run: pnpm validate-content
@@ -105,6 +104,28 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm tsx scripts/check-pr-comments.ts ${{ github.event.pull_request.number }}
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: typecheck-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm tsc --noEmit
 
   test:
     runs-on: ubuntu-latest
@@ -227,7 +248,7 @@ jobs:
       id-token: write
       attestations: write
     timeout-minutes: 12
-    needs: [quality, test]
+    needs: [quality-fast, typecheck, test]
     concurrency:
       group: build-${{ github.ref }}
       cancel-in-progress: true

--- a/scripts/lib/scan-css.mjs
+++ b/scripts/lib/scan-css.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // Shared utilities for CSS module scanning scripts.
 import { readFileSync } from 'node:fs';
 import { glob } from 'node:fs/promises';

--- a/scripts/lib/scan-css.mjs
+++ b/scripts/lib/scan-css.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Shared utilities for CSS module scanning scripts.
+import { readFileSync } from 'node:fs';
+import { glob } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+const CSS_IGNORE = ['node_modules/**', '.next/**', '.claude/**', 'design-system/dist/**'];
+
+/** Strip block comments, preserving line count. */
+export function stripComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, (match) => match.replace(/[^\n]/g, ' '));
+}
+
+/**
+ * Glob all *.module.css files under ROOT.
+ * Returns array of { rel, abs, raw, stripped } sorted by rel path.
+ * `stripped` has block comments removed. Callers apply additional preprocessing.
+ */
+export async function scanCssModules() {
+  const files = await Array.fromAsync(glob('**/*.module.css', { cwd: ROOT, ignore: CSS_IGNORE }));
+  return files.sort().map((rel) => {
+    const abs = path.join(ROOT, rel);
+    const raw = readFileSync(abs, 'utf8');
+    return { rel, abs, raw, stripped: stripComments(raw) };
+  });
+}

--- a/scripts/lint-no-magic-values.mjs
+++ b/scripts/lint-no-magic-values.mjs
@@ -7,11 +7,9 @@
 //   - px values inside @media conditions (those are breakpoints, not layout tokens)
 //   - Values already in the allowlist with documented reasons
 import { readFileSync } from 'node:fs';
-import { glob } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { ROOT, scanCssModules } from './lib/scan-css.mjs';
 
-const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const allowlist = JSON.parse(
   readFileSync(path.join(ROOT, 'scripts/lint-no-magic-values.allowlist.json'), 'utf8'),
 );
@@ -24,14 +22,6 @@ const allowedZIndex = new Set(
   allowlist['z-index-values'].map((e) => (typeof e === 'string' ? e : e.value)),
 );
 const allowedColorFunctions = new Set((allowlist['color-functions'] ?? []).map((e) => e.value));
-
-/**
- * Strip CSS block comments from content so we never flag values inside them.
- * Preserves line count by replacing comment bodies with spaces.
- */
-function stripComments(css) {
-  return css.replace(/\/\*[\s\S]*?\*\//g, (match) => match.replace(/[^\n]/g, ' '));
-}
 
 /**
  * Strip @media condition strings so breakpoint px values (768px, 900px, etc.)
@@ -100,20 +90,14 @@ const checks = [
   },
 ];
 
-const files = await Array.fromAsync(
-  glob('**/*.module.css', {
-    cwd: ROOT,
-    ignore: ['node_modules/**', '.next/**', '.claude/**', 'design-system/dist/**'],
-  }),
-);
+const cssFiles = await scanCssModules();
 
 let violations = 0;
-for (const rel of files.sort()) {
-  const abs = path.join(ROOT, rel);
-  const raw = readFileSync(abs, 'utf8');
-  // Strip comments, media conditions, and var() calls before scanning for values.
-  // Order matters: strip comments first so var() inside comments don't suppress real findings.
-  const content = stripVarCalls(stripMediaConditions(stripComments(raw)));
+for (const { rel, stripped } of cssFiles) {
+  // Strip media conditions and var() calls before scanning for values.
+  // Comments are already stripped by scanCssModules(). Order matters:
+  // strip media conditions before var() calls to avoid false-positives.
+  const content = stripVarCalls(stripMediaConditions(stripped));
   for (const check of checks) {
     for (const match of content.matchAll(check.pattern)) {
       const val = check.extract ? check.extract(match[0], match[1]) : match[0];
@@ -128,4 +112,4 @@ if (violations > 0) {
   console.error(`\n${violations} magic value(s) found. Fix or add to allowlist.`);
   process.exit(1);
 }
-console.log(`No-magic-values check passed (${files.length} files).`);
+console.log(`No-magic-values check passed (${cssFiles.length} files).`);

--- a/scripts/lint-token-boundary.mjs
+++ b/scripts/lint-token-boundary.mjs
@@ -27,11 +27,11 @@ const FORBIDDEN = [
   },
 ];
 
-// Scan all .module.css files except the dist/tokens.css file (primitives are valid there).
+// Scan all .module.css files; design-system/dist/** is excluded by scanCssModules().
 const cssFiles = await scanCssModules();
 
 let violations = 0;
-for (const { rel, stripped: content } of cssFiles) {
+for (const { rel, raw: content } of cssFiles) {
   for (const { pattern, hint } of FORBIDDEN) {
     const matches = content.match(pattern);
     if (matches) {

--- a/scripts/lint-token-boundary.mjs
+++ b/scripts/lint-token-boundary.mjs
@@ -1,12 +1,7 @@
 #!/usr/bin/env node
 // Rejects direct primitive references in .module.css when a semantic alias exists.
 // Run: node scripts/lint-token-boundary.mjs
-import { readFileSync } from 'node:fs';
-import { glob } from 'node:fs/promises';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+import { scanCssModules } from './lib/scan-css.mjs';
 
 // Patterns that are FORBIDDEN (primitives that have semantic aliases).
 // Each regex matches only the specific token shape that must be aliased:
@@ -33,17 +28,10 @@ const FORBIDDEN = [
 ];
 
 // Scan all .module.css files except the dist/tokens.css file (primitives are valid there).
-const files = await Array.fromAsync(
-  glob('**/*.module.css', {
-    cwd: ROOT,
-    ignore: ['node_modules/**', '.next/**', '.claude/**', 'design-system/dist/**'],
-  }),
-);
+const cssFiles = await scanCssModules();
 
 let violations = 0;
-for (const rel of files) {
-  const abs = path.join(ROOT, rel);
-  const content = readFileSync(abs, 'utf8');
+for (const { rel, stripped: content } of cssFiles) {
   for (const { pattern, hint } of FORBIDDEN) {
     const matches = content.match(pattern);
     if (matches) {
@@ -59,4 +47,4 @@ if (violations > 0) {
   console.error(`\n${violations} token boundary violation(s). Fix before merging.`);
   process.exit(1);
 }
-console.log(`Token boundary check passed (${files.length} files).`);
+console.log(`Token boundary check passed (${cssFiles.length} files).`);


### PR DESCRIPTION
## Summary

<!-- What changed and why. 2-3 bullets. -->

- **P3-10 (shared CSS scanner):** Extracted `scripts/lib/scan-css.mjs` — `ROOT`, `stripComments`, and the module.css glob with its ignore list now live in one place; `lint-token-boundary.mjs` and `lint-no-magic-values.mjs` both import from it so the ignore list cannot drift out of sync between the two linters.
- **P3-9 (parallel quality CI):** Split the single `quality` job (13 sequential steps, ~37s wall-clock) into `quality-fast` (all checks except tsc, ~10s) and `typecheck` (tsc only, ~25s) running in parallel — reduces quality gate wall-clock from ~37s to ~25s. The `build` job now gates on both parallel jobs.
- **Post-merge manual action required:** Update GitHub branch protection (Settings → Branches → main → Required status checks): remove `quality`, add `quality-fast` and `typecheck`.

## Type of change

- [ ] `feat` — new functionality
- [ ] `fix` — bug fix
- [x] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

<!-- How was this verified? Include command output or screenshots. -->

- [x] `pnpm ci:local` passes (85 test files, 565 tests, all green)
- [ ] New behaviour covered by tests
- The refactored CSS scanner is purely structural (no logic change); existing `pnpm check`, `pnpm lint-token-boundary`, and `pnpm lint-no-magic-values` scripts exercise the shared module on every ci:local run.

## Visual changes

No UI changes. Deleting this section is not applicable — keeping it for template completeness.

- [ ] Desktop (1280×720) checked via Playwright MCP
- [ ] Mobile (375×812) checked via Playwright MCP
- [x] No visual regressions introduced (no CSS, JSX, or asset changes)

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — scripts only, no CSS changed
- [x] No `use client` added without necessity (RSC drift) — no component changes
- [x] Bundle size impact assessed (`pnpm bundle-check`) — no runtime code changed; bundle unaffected
- [x] A11y impact considered (axe-core will gate in CI) — no markup or interaction changes
- [ ] ADR added to `DECISIONS.md` if this changes architecture — tooling-only change; not an architecture decision