### PR TITLE
fix(daw-mixer): hide signal-flow arrow in mobile channel plugin chain

### DIFF
--- a/components/sections/DawMixerSection/DawMixerSection.module.css
+++ b/components/sections/DawMixerSection/DawMixerSection.module.css
@@ -580,6 +580,12 @@
   font-size: var(--ds-font-size-2xs);
   text-shadow: 0 0 4px var(--ds-color-signal);
 }
+.rootMobile .mxChain::after {
+  display: none;
+}
+.rootMobile .mxChain {
+  padding-bottom: 0;
+}
 .mxPlug {
   display: grid;
   grid-template-columns: 14px minmax(90px, auto) 1fr;

--- a/tests/e2e/cross-cutting.spec.ts
+++ b/tests/e2e/cross-cutting.spec.ts
@@ -387,12 +387,12 @@ test.describe('cross-cutting', () => {
   });
 
   test('6 — DAW mixer mobile CSS override is compiled into the bundle', async ({ page }) => {
-    // DawMixerMobile only renders when the server UA-detects a mobile agent.
-    // E2E tests use a desktop UA so the component is never in the DOM — the
-    // only automated check available is stylesheet inspection. This asserts
-    // the compiled bundle contains the .rootMobile .mxChain::after override
-    // that hides the orphaned signal-flow arrow on mobile, so any accidental
-    // deletion of the CSS rule will fail CI before reaching production.
+    // Stylesheet inspection is used here because getComputedStyle on a ::after
+    // pseudo-element requires the element to be in the DOM, and the DAW mixer
+    // renders either DawMixerDesktop or DawMixerMobile based on server-side UA
+    // detection — making DOM-based assertions project-dependent. Checking the
+    // compiled stylesheet directly is deterministic across all four projects
+    // and catches any accidental deletion of the scoped CSS override.
     await page.goto(BASE_URL);
     await page.waitForSelector('[data-testid="hero-name"]', { state: 'attached' });
 
@@ -401,7 +401,11 @@ test.describe('cross-cutting', () => {
         try {
           for (const rule of sheet.cssRules) {
             const text = rule.cssText ?? '';
+            // The selector must reference both rootMobile (parent scope) and
+            // mxChain::after (the arrow pseudo-element being hidden). An
+            // unscoped `.mxChain::after { display:none }` would not qualify.
             if (
+              text.includes('rootMobile') &&
               text.includes('mxChain') &&
               text.includes('::after') &&
               text.includes('display: none')
@@ -418,7 +422,7 @@ test.describe('cross-cutting', () => {
 
     expect(
       ruleFound,
-      'compiled CSS bundle must contain a .mxChain::after { display: none } rule scoped to the mobile root',
+      'compiled CSS bundle must contain a .rootMobile .mxChain::after { display: none } scoped rule',
     ).toBe(true);
   });
 });

--- a/tests/e2e/cross-cutting.spec.ts
+++ b/tests/e2e/cross-cutting.spec.ts
@@ -385,4 +385,40 @@ test.describe('cross-cutting', () => {
       `motion toggle → next paint should be <200ms (got ${elapsedMs.toFixed(1)}ms)`,
     ).toBeLessThan(200);
   });
+
+  test('6 — DAW mixer mobile CSS override is compiled into the bundle', async ({ page }) => {
+    // DawMixerMobile only renders when the server UA-detects a mobile agent.
+    // E2E tests use a desktop UA so the component is never in the DOM — the
+    // only automated check available is stylesheet inspection. This asserts
+    // the compiled bundle contains the .rootMobile .mxChain::after override
+    // that hides the orphaned signal-flow arrow on mobile, so any accidental
+    // deletion of the CSS rule will fail CI before reaching production.
+    await page.goto(BASE_URL);
+    await page.waitForSelector('[data-testid="hero-name"]', { state: 'attached' });
+
+    const ruleFound = await page.evaluate((): boolean => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            const text = rule.cssText ?? '';
+            if (
+              text.includes('mxChain') &&
+              text.includes('::after') &&
+              text.includes('display: none')
+            ) {
+              return true;
+            }
+          }
+        } catch {
+          // cross-origin sheets throw SecurityError — skip
+        }
+      }
+      return false;
+    });
+
+    expect(
+      ruleFound,
+      'compiled CSS bundle must contain a .mxChain::after { display: none } rule scoped to the mobile root',
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- The `▼` signal-flow arrow terminator (`.mxChain::after`) was orphaned in mobile after the view was narrowed to 2 channels in PR #63
- Hide the arrow and remove the 10px `padding-bottom` that was reserved solely for it when inside `.rootMobile`
- Desktop layout is unaffected — the scoping rule only targets `.rootMobile .mxChain::after`

## Type of change

- [x] `fix` — bug fix

## Test plan

- [x] `pnpm ci:local` passes
- [x] CSS rule verified live in browser: `.rootMobile .mxChain::after { display: none }` confirmed present in stylesheet via Playwright `evaluate`
- [x] New behaviour covered by tests

## Visual changes

- [x] Desktop (1280×720) checked via Playwright MCP — desktop arrow unchanged
- [x] Mobile (375×812) checked via Playwright MCP — CSS rule confirmed compiled; mobile UA required for RSC path (server-side `getIsMobile()`), rule verified via stylesheet evaluation
- [x] No visual regressions introduced

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary)
- [x] No `use client` added without necessity (RSC drift)
- [x] Bundle size impact assessed (`pnpm bundle-check`) — CSS-only, negligible
- [x] A11y impact considered — arrow was already `aria-hidden` via parent wrapper; no AT impact
- [x] ADR added to `DECISIONS.md` if this changes architecture — not required for visual cleanup