### PR TITLE
style(ui): section background variants + green contact placeholders

### DIFF
--- a/components/responsive/Module/Module.module.css
+++ b/components/responsive/Module/Module.module.css
@@ -127,8 +127,7 @@
 .bodyContent {
   padding: var(--ds-space-pad);
   color: var(--ds-color-text-body);
-  /* Default: SESSION_REPORT gradient — matches the footer panel treatment. */
-  background: linear-gradient(180deg, rgba(0, 255, 65, 0.025), rgba(0, 0, 0, 0));
+  background: transparent;
   /* Closing: fade over the full 300ms in sync with the height collapse so
      content and container reach 0 together rather than content vanishing first. */
   opacity: 0;

--- a/components/responsive/Module/Module.module.css
+++ b/components/responsive/Module/Module.module.css
@@ -127,13 +127,16 @@
 .bodyContent {
   padding: var(--ds-space-pad);
   color: var(--ds-color-text-body);
-  /* Subtle signal tint so content reads against the black background — same on
-     mobile and desktop so both viewports look identical. */
-  background: rgba(0, 255, 65, 0.05);
+  /* Default: SESSION_REPORT gradient — matches the footer panel treatment. */
+  background: linear-gradient(180deg, rgba(0, 255, 65, 0.025), rgba(0, 0, 0, 0));
   /* Closing: fade over the full 300ms in sync with the height collapse so
      content and container reach 0 together rather than content vanishing first. */
   opacity: 0;
   transition: opacity var(--ds-duration-slow) cubic-bezier(0.32, 0, 0.67, 0);
+}
+
+.bodyContentGreen {
+  background: rgba(0, 255, 65, 0.05);
 }
 
 .root[open] .bodyContent {

--- a/components/responsive/Module/Module.tsx
+++ b/components/responsive/Module/Module.tsx
@@ -32,10 +32,23 @@ export type ModuleProps = {
   icon?: ReactNode;
   /** Applies content-visibility:auto deferral for below-fold modules. */
   defer?: boolean | undefined;
+  /**
+   * "green": full rgba(0,255,65,0.05) tint — for data-heavy/interactive sections.
+   * Default: SESSION_REPORT-style subtle gradient — for narrative/context sections.
+   */
+  variant?: 'green';
   children: ReactNode;
 };
 
-export function Module({ id, header, mobileHeader, icon, defer = false, children }: ModuleProps) {
+export function Module({
+  id,
+  header,
+  mobileHeader,
+  icon,
+  defer = false,
+  variant,
+  children,
+}: ModuleProps) {
   return (
     <details
       id={id}
@@ -63,7 +76,15 @@ export function Module({ id, header, mobileHeader, icon, defer = false, children
         {/* bodyInner: grid item — no padding so 0fr collapses to true 0.
             bodyContent: padding+color wrapper inside the overflow:hidden clip. */}
         <div className={styles.bodyInner}>
-          <div className={styles.bodyContent}>{children}</div>
+          <div
+            className={
+              variant === 'green'
+                ? `${styles.bodyContent} ${styles.bodyContentGreen}`
+                : styles.bodyContent
+            }
+          >
+            {children}
+          </div>
         </div>
       </div>
     </details>

--- a/components/sections/AiMetricsSection/AiMetricsSection.tsx
+++ b/components/sections/AiMetricsSection/AiMetricsSection.tsx
@@ -93,6 +93,7 @@ export function AiMetricsSection({ defer }: { defer?: boolean } = {}) {
     <Module
       id="sec-ai-metrics"
       header="ASK_EVAL.JSON --MEASURED"
+      variant="green"
       mobileHeader="ASK_EVAL.JSON"
       icon={<IconAiMetrics />}
       defer={defer}

--- a/components/sections/ContactSection/ContactSection.tsx
+++ b/components/sections/ContactSection/ContactSection.tsx
@@ -11,6 +11,7 @@ export function ContactSection({ defer }: { defer?: boolean } = {}) {
       mobileHeader="CONTACT"
       icon={<IconContact />}
       defer={defer}
+      variant="green"
     >
       <ErrorBoundary>
         <ContactFormLazy />

--- a/components/sections/DawMixerSection/DawMixerSection.tsx
+++ b/components/sections/DawMixerSection/DawMixerSection.tsx
@@ -236,7 +236,13 @@ export async function DawMixerContent() {
 
 export function DawMixerSection({ defer }: { defer?: boolean } = {}) {
   return (
-    <Module id="sec-daw-mixer" header="./MIX --LIVE — DAW MIXER" icon={<IconMixer />} defer={defer}>
+    <Module
+      id="sec-daw-mixer"
+      header="./MIX --LIVE — DAW MIXER"
+      icon={<IconMixer />}
+      defer={defer}
+      variant="green"
+    >
       <Suspense fallback={null}>
         <DawMixerContent />
       </Suspense>

--- a/components/sections/GuitarSection/GuitarSection.tsx
+++ b/components/sections/GuitarSection/GuitarSection.tsx
@@ -245,7 +245,13 @@ export async function GuitarContent() {
 
 export function GuitarSection({ defer }: { defer?: boolean } = {}) {
   return (
-    <Module id="sec-guitar" header="CAT ~/.GUITAR_RIG" icon={<IconGuitar />} defer={defer}>
+    <Module
+      id="sec-guitar"
+      header="CAT ~/.GUITAR_RIG"
+      icon={<IconGuitar />}
+      defer={defer}
+      variant="green"
+    >
       <Suspense fallback={null}>
         <GuitarContent />
       </Suspense>

--- a/components/sections/LivePerfSection/LivePerfSection.tsx
+++ b/components/sections/LivePerfSection/LivePerfSection.tsx
@@ -81,6 +81,7 @@ export function LivePerfSection({ defer }: { defer?: boolean } = {}) {
     <Module
       id="sec-live-perf"
       header="LIVE_PERF.JSON"
+      variant="green"
       mobileHeader="LIVE_PERF · LIGHTHOUSE"
       icon={<IconLivePerf />}
       defer={defer}

--- a/components/sections/ManPageSection/ManPageSection.tsx
+++ b/components/sections/ManPageSection/ManPageSection.tsx
@@ -12,7 +12,13 @@ export async function ManPageContent() {
 
 export function ManPageSection({ defer }: { defer?: boolean } = {}) {
   return (
-    <Module id="sec-man-page" header="MAN ERIK(1)" icon={<IconManPage />} defer={defer}>
+    <Module
+      id="sec-man-page"
+      header="MAN ERIK(1)"
+      icon={<IconManPage />}
+      defer={defer}
+      variant="green"
+    >
       <Suspense fallback={<ManPageDesktop />}>
         <ManPageContent />
       </Suspense>

--- a/components/sections/NpmStackSection/NpmStackSection.tsx
+++ b/components/sections/NpmStackSection/NpmStackSection.tsx
@@ -5,7 +5,13 @@ import styles from './NpmStackSection.module.css';
 
 export function NpmStackSection({ defer }: { defer?: boolean } = {}) {
   return (
-    <Module id="sec-npm-stack" header="NPM LIST --GLOBAL" icon={<IconNpmStack />} defer={defer}>
+    <Module
+      id="sec-npm-stack"
+      header="NPM LIST --GLOBAL"
+      icon={<IconNpmStack />}
+      defer={defer}
+      variant="green"
+    >
       <ul className={styles.root}>
         {npmStack.map((t) => (
           <li key={t.label}>

--- a/components/sections/PerfReceiptsSection/PerfReceiptsSection.tsx
+++ b/components/sections/PerfReceiptsSection/PerfReceiptsSection.tsx
@@ -47,6 +47,7 @@ export function PerfReceiptsSection({ defer }: { defer?: boolean } = {}) {
     <Module
       id="sec-perf-receipts"
       header="PERF_RECEIPTS --HARD-NUMBERS"
+      variant="green"
       mobileHeader="PERF_RECEIPTS"
       icon={<IconPerfReceipts />}
       defer={defer}

--- a/components/sections/ProjectsSection/ProjectsSection.tsx
+++ b/components/sections/ProjectsSection/ProjectsSection.tsx
@@ -75,6 +75,7 @@ export function ProjectsSection({ defer }: { defer?: boolean } = {}) {
     <Module
       id="sec-projects"
       header="LS -LA ./PROJECTS"
+      variant="green"
       mobileHeader="LS -LA ~/PROJECTS"
       icon={<IconProjects />}
       defer={defer}

--- a/components/sections/SysHealthSection/SysHealthSection.tsx
+++ b/components/sections/SysHealthSection/SysHealthSection.tsx
@@ -5,7 +5,13 @@ import styles from './SysHealthSection.module.css';
 
 export function SysHealthSection({ defer }: { defer?: boolean } = {}) {
   return (
-    <Module id="sec-sys-health" header="SYS_HEALTH_MONITOR" icon={<IconSysHealth />} defer={defer}>
+    <Module
+      id="sec-sys-health"
+      header="SYS_HEALTH_MONITOR"
+      icon={<IconSysHealth />}
+      defer={defer}
+      variant="green"
+    >
       <div className={styles.root}>
         {sysStats.map((s) => (
           <div key={s.label} className={styles.stat}>

--- a/design-system/components/Field/Field.module.css
+++ b/design-system/components/Field/Field.module.css
@@ -20,6 +20,10 @@
   resize: vertical;
   transition: border-color var(--ds-duration-base) var(--ds-ease-out);
 }
+.input::placeholder {
+  color: var(--ds-color-signal);
+  opacity: 0.6;
+}
 .input:focus-visible {
   border-color: var(--ds-color-signal);
 }

--- a/docs/superpowers/plans/2026-05-29-psi-refresh-cron.md
+++ b/docs/superpowers/plans/2026-05-29-psi-refresh-cron.md
@@ -1,0 +1,905 @@
+# PSI Refresh Cron Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Vercel cron that proactively refreshes desktop + mobile PSI Lighthouse scores in Redis daily, and update `LIVE_PERF.JSON` to display both strategies in a stacked layout.
+
+**Architecture:** Extend `lib/lighthouse-scores.ts` with a `strategy` param and `refreshScores()` export; add `app/api/psi-refresh/route.ts` (auth-gated GET); add `vercel.json` with a daily 3 AM UTC cron; update `LivePerfSection` to render two stacked `<PerfData>` instances (desktop + mobile), fetched in parallel at RSC render time.
+
+**Tech Stack:** Next.js 16 App Router · Upstash Redis (`getRedis()` from `lib/rate-limit.ts`) · Vercel cron · PageSpeed Insights API (`PSI_API_KEY`) · Vitest · `renderToStaticMarkup` for RSC tests
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `lib/lighthouse-scores.ts` | Modify | Add `Strategy` type, split Redis keys, add `refreshScores`, extract `fetchAndCache` |
+| `__tests__/lighthouse-scores.test.ts` | Create | Unit tests for `getScores` (cache-hit, cache-miss, fallback) + `refreshScores` |
+| `__tests__/lighthouse-fallback.test.ts` | No change | Shape of `LIGHTHOUSE_FALLBACK` — unchanged |
+| `app/api/psi-refresh/route.ts` | Create | Cron handler: auth check + parallel refresh + JSON response |
+| `__tests__/psi-refresh-route.test.ts` | Create | 401 on bad auth, 200 with both strategies, partial failure |
+| `vercel.json` | Create | `{ "crons": [{ "path": "/api/psi-refresh", "schedule": "0 3 * * *" }] }` |
+| `components/sections/LivePerfSection/LivePerfSection.tsx` | Modify | Add `strategy` prop to `PerfData`; render two stacked blocks in `LivePerfSection` |
+| `components/sections/LivePerfSection/LivePerfSection.module.css` | Modify | Add `.strategyBlock` + `.strategyLabel` |
+| `components/sections/LivePerfSection/LivePerfSection.test.tsx` | Modify | Update mocks + assertions for desktop/mobile strategy args |
+| `.env.example` | Modify | Add `CRON_SECRET` variable |
+| `DECISIONS.md` | Modify | Document cron architecture, TTL rationale, strategy split |
+
+---
+
+## Task 1: Extend `lib/lighthouse-scores.ts`
+
+**Files:**
+- Modify: `lib/lighthouse-scores.ts`
+- Create: `__tests__/lighthouse-scores.test.ts`
+
+### Step 1: Write the failing tests
+
+- [ ] Create `__tests__/lighthouse-scores.test.ts`:
+
+```typescript
+// __tests__/lighthouse-scores.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+vi.mock('@/lib/rate-limit', () => ({
+  getRedis: () => ({ get: mockGet, set: mockSet }),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const mockLogError = vi.fn();
+vi.mock('@/lib/log', () => ({ log: { error: mockLogError, info: vi.fn() } }));
+
+afterEach(() => {
+  vi.resetModules();
+  mockGet.mockReset();
+  mockSet.mockReset();
+  mockFetch.mockReset();
+  mockLogError.mockReset();
+});
+
+const CACHED_DESKTOP = {
+  performance: 99, accessibility: 100, bestPractices: 95, seo: 100,
+  fetchedAt: '2026-05-29T03:00:00.000Z',
+};
+
+function makePsiResponse(score = 0.99) {
+  return {
+    ok: true,
+    json: async () => ({
+      lighthouseResult: {
+        categories: {
+          performance: { score },
+          accessibility: { score: 1 },
+          'best-practices': { score: 0.95 },
+          seo: { score: 1 },
+        },
+      },
+    }),
+  };
+}
+
+describe('getScores — cache hit', () => {
+  it('returns cached value without fetching PSI', async () => {
+    mockGet.mockResolvedValue(CACHED_DESKTOP);
+    const { getScores } = await import('@/lib/lighthouse-scores');
+    const result = await getScores('desktop');
+    expect(result).toEqual(CACHED_DESKTOP);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('defaults to desktop strategy', async () => {
+    mockGet.mockResolvedValue(CACHED_DESKTOP);
+    const { getScores } = await import('@/lib/lighthouse-scores');
+    await getScores();
+    expect(mockGet).toHaveBeenCalledWith('lh:scores:desktop');
+  });
+
+  it('uses lh:scores:mobile key for mobile strategy', async () => {
+    mockGet.mockResolvedValue(CACHED_DESKTOP);
+    const { getScores } = await import('@/lib/lighthouse-scores');
+    await getScores('mobile');
+    expect(mockGet).toHaveBeenCalledWith('lh:scores:mobile');
+  });
+});
+
+describe('getScores — cache miss', () => {
+  it('fetches from PSI and returns scores', async () => {
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue('OK');
+    process.env.PSI_API_KEY = 'test-key';
+    mockFetch.mockResolvedValue(makePsiResponse(0.99));
+    const { getScores } = await import('@/lib/lighthouse-scores');
+    const result = await getScores('desktop');
+    expect(result.performance).toBe(99);
+    expect(result.fetchedAt).not.toBe('—');
+    delete process.env.PSI_API_KEY;
+  });
+
+  it('writes result to Redis with TTL', async () => {
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue('OK');
+    process.env.PSI_API_KEY = 'test-key';
+    mockFetch.mockResolvedValue(makePsiResponse(0.95));
+    const { getScores, LIGHTHOUSE_TTL_S } = await import('@/lib/lighthouse-scores');
+    await getScores('desktop');
+    // fire-and-forget; wait a tick for the promise to settle
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockSet).toHaveBeenCalledWith(
+      'lh:scores:desktop',
+      expect.objectContaining({ performance: 95 }),
+      { ex: LIGHTHOUSE_TTL_S },
+    );
+    delete process.env.PSI_API_KEY;
+  });
+
+  it('returns LIGHTHOUSE_FALLBACK when PSI_API_KEY is absent', async () => {
+    mockGet.mockResolvedValue(null);
+    delete process.env.PSI_API_KEY;
+    const { getScores, LIGHTHOUSE_FALLBACK } = await import('@/lib/lighthouse-scores');
+    const result = await getScores('desktop');
+    expect(result).toEqual(LIGHTHOUSE_FALLBACK);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns LIGHTHOUSE_FALLBACK when PSI fetch throws', async () => {
+    mockGet.mockResolvedValue(null);
+    process.env.PSI_API_KEY = 'test-key';
+    mockFetch.mockRejectedValue(new Error('network error'));
+    const { getScores, LIGHTHOUSE_FALLBACK } = await import('@/lib/lighthouse-scores');
+    const result = await getScores('desktop');
+    expect(result).toEqual(LIGHTHOUSE_FALLBACK);
+    delete process.env.PSI_API_KEY;
+  });
+});
+
+describe('refreshScores', () => {
+  it('fetches from PSI even when cache is warm', async () => {
+    mockGet.mockResolvedValue(CACHED_DESKTOP); // cache has data
+    mockSet.mockResolvedValue('OK');
+    process.env.PSI_API_KEY = 'test-key';
+    mockFetch.mockResolvedValue(makePsiResponse(0.98));
+    const { refreshScores } = await import('@/lib/lighthouse-scores');
+    const result = await refreshScores('desktop');
+    expect(result.performance).toBe(98);
+    expect(mockFetch).toHaveBeenCalledOnce(); // PSI was called despite warm cache
+    delete process.env.PSI_API_KEY;
+  });
+
+  it('throws when PSI fetch fails', async () => {
+    process.env.PSI_API_KEY = 'test-key';
+    mockFetch.mockRejectedValue(new Error('PSI down'));
+    const { refreshScores } = await import('@/lib/lighthouse-scores');
+    await expect(refreshScores('desktop')).rejects.toThrow('PSI down');
+    delete process.env.PSI_API_KEY;
+  });
+
+  it('throws when PSI_API_KEY is absent', async () => {
+    delete process.env.PSI_API_KEY;
+    const { refreshScores } = await import('@/lib/lighthouse-scores');
+    await expect(refreshScores('desktop')).rejects.toThrow();
+  });
+});
+```
+
+- [ ] Run the tests to confirm they fail:
+
+```bash
+pnpm test --run __tests__/lighthouse-scores.test.ts 2>&1 | tail -10
+```
+
+Expected: multiple failures — `getScores` doesn't accept a `strategy` param, `refreshScores` doesn't exist.
+
+### Step 2: Implement the changes
+
+- [ ] Replace `lib/lighthouse-scores.ts` with:
+
+```typescript
+import { log } from '@/lib/log';
+import { getRedis } from './rate-limit';
+
+export type Strategy = 'desktop' | 'mobile';
+
+export type LighthouseScores = {
+  performance: number;
+  accessibility: number;
+  bestPractices: number;
+  seo: number;
+  fetchedAt: string;
+};
+
+export const LIGHTHOUSE_FALLBACK: LighthouseScores = {
+  performance: 0,
+  accessibility: 0,
+  bestPractices: 0,
+  seo: 0,
+  fetchedAt: '—',
+};
+
+const CACHE_KEY = (strategy: Strategy) => `lh:scores:${strategy}`;
+export const LIGHTHOUSE_TTL_S = 90_000; // 25 h — survives a missed cron run
+
+async function fetchAndCache(strategy: Strategy): Promise<LighthouseScores> {
+  const apiKey = process.env.PSI_API_KEY;
+  if (!apiKey) throw new Error('PSI_API_KEY is not set');
+
+  const psiUrl =
+    'https://www.googleapis.com/pagespeedonline/v5/runPagespeed' +
+    `?url=${encodeURIComponent('https://www.erikunha.dev')}` +
+    `&strategy=${strategy}` +
+    `&key=${apiKey}` +
+    '&category=PERFORMANCE&category=ACCESSIBILITY&category=BEST_PRACTICES&category=SEO';
+
+  const res = await fetch(psiUrl, {
+    next: { revalidate: LIGHTHOUSE_TTL_S },
+    signal: AbortSignal.timeout(8_000),
+    headers: { Referer: 'https://www.erikunha.dev/' },
+  });
+  if (!res.ok) throw new Error(`PSI API returned ${res.status}`);
+
+  const data = (await res.json()) as {
+    lighthouseResult?: {
+      categories?: {
+        performance?: { score?: number };
+        accessibility?: { score?: number };
+        'best-practices'?: { score?: number };
+        seo?: { score?: number };
+      };
+    };
+  };
+  const cats = data.lighthouseResult?.categories ?? {};
+  const scores: LighthouseScores = {
+    performance: Math.round((cats.performance?.score ?? 1) * 100),
+    accessibility: Math.round((cats.accessibility?.score ?? 1) * 100),
+    bestPractices: Math.round((cats['best-practices']?.score ?? 0.98) * 100),
+    seo: Math.round((cats.seo?.score ?? 1) * 100),
+    fetchedAt: new Date().toISOString(),
+  };
+
+  // Fire-and-forget — don't let cache failure block the response.
+  getRedis()
+    .set(CACHE_KEY(strategy), scores, { ex: LIGHTHOUSE_TTL_S })
+    .catch((err) => log.error('Redis cache set failed', { err }));
+
+  return scores;
+}
+
+/**
+ * Cache-first. Returns cached scores if available; fetches from PSI on miss.
+ * Falls back to LIGHTHOUSE_FALLBACK on any error. Default strategy: desktop.
+ */
+export async function getScores(strategy: Strategy = 'desktop'): Promise<LighthouseScores> {
+  const cached = await getRedis()
+    .get<LighthouseScores>(CACHE_KEY(strategy))
+    .catch(() => null);
+  if (cached) return cached;
+
+  try {
+    return await fetchAndCache(strategy);
+  } catch (err) {
+    log.error('PSI fetch failed', { err, strategy });
+    return LIGHTHOUSE_FALLBACK;
+  }
+}
+
+/**
+ * Always fetches from PSI and updates cache. Used by the cron handler.
+ * Throws on PSI failure — caller handles per-strategy via Promise.allSettled.
+ */
+export async function refreshScores(strategy: Strategy): Promise<LighthouseScores> {
+  return fetchAndCache(strategy);
+}
+```
+
+### Step 3: Run tests and verify
+
+- [ ] Run:
+
+```bash
+pnpm test --run __tests__/lighthouse-scores.test.ts 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] Run the full suite to check for regressions:
+
+```bash
+pnpm test --run 2>&1 | tail -5
+```
+
+Expected: `655 passed` (all prior tests still pass).
+
+### Step 4: Commit
+
+- [ ] Run:
+
+```bash
+git add lib/lighthouse-scores.ts __tests__/lighthouse-scores.test.ts
+git commit -m "feat(perf): split lighthouse scores by strategy (desktop/mobile), add refreshScores"
+```
+
+---
+
+## Task 2: Cron Handler `app/api/psi-refresh/route.ts`
+
+**Files:**
+- Create: `app/api/psi-refresh/route.ts`
+- Create: `__tests__/psi-refresh-route.test.ts`
+
+### Step 1: Write the failing tests
+
+- [ ] Create `__tests__/psi-refresh-route.test.ts`:
+
+```typescript
+// __tests__/psi-refresh-route.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockRefreshScores = vi.fn();
+vi.mock('@/lib/lighthouse-scores', () => ({
+  refreshScores: mockRefreshScores,
+}));
+
+const mockLogInfo = vi.fn();
+vi.mock('@/lib/log', () => ({ log: { info: mockLogInfo, error: vi.fn() } }));
+
+afterEach(() => {
+  vi.resetModules();
+  mockRefreshScores.mockReset();
+  mockLogInfo.mockReset();
+  delete process.env.CRON_SECRET;
+});
+
+function makeRequest(authHeader?: string) {
+  return new Request('http://localhost/api/psi-refresh', {
+    method: 'GET',
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+const DESKTOP_SCORES = {
+  performance: 99, accessibility: 100, bestPractices: 95, seo: 100,
+  fetchedAt: '2026-05-29T03:00:00.000Z',
+};
+const MOBILE_SCORES = {
+  performance: 90, accessibility: 100, bestPractices: 95, seo: 100,
+  fetchedAt: '2026-05-29T03:00:01.000Z',
+};
+
+describe('GET /api/psi-refresh — auth', () => {
+  it('returns 401 when CRON_SECRET is not set', async () => {
+    const { GET } = await import('@/app/api/psi-refresh/route');
+    const res = await GET(makeRequest('Bearer anything') as any);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    process.env.CRON_SECRET = 'secret123';
+    const { GET } = await import('@/app/api/psi-refresh/route');
+    const res = await GET(makeRequest() as any);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when Bearer token does not match CRON_SECRET', async () => {
+    process.env.CRON_SECRET = 'secret123';
+    const { GET } = await import('@/app/api/psi-refresh/route');
+    const res = await GET(makeRequest('Bearer wrong') as any);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/psi-refresh — success', () => {
+  it('returns 200 with desktop and mobile scores', async () => {
+    process.env.CRON_SECRET = 'secret123';
+    mockRefreshScores
+      .mockResolvedValueOnce(DESKTOP_SCORES)
+      .mockResolvedValueOnce(MOBILE_SCORES);
+    const { GET } = await import('@/app/api/psi-refresh/route');
+    const res = await GET(makeRequest('Bearer secret123') as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.desktop).toEqual(DESKTOP_SCORES);
+    expect(body.mobile).toEqual(MOBILE_SCORES);
+    expect(typeof body.durationMs).toBe('number');
+  });
+
+  it('calls refreshScores for both desktop and mobile', async () => {
+    process.env.CRON_SECRET = 'secret123';
+    mockRefreshScores.mockResolvedValue(DESKTOP_SCORES);
+    const { GET } = await import('@/app/api/psi-refresh/route');
+    await GET(makeRequest('Bearer secret123') as any);
+    expect(mockRefreshScores).toHaveBeenCalledWith('desktop');
+    expect(mockRefreshScores).toHaveBeenCalledWith('mobile');
+  });
+
+  it('returns null for a failed strategy while the other succeeds', async () => {
+    process.env.CRON_SECRET = 'secret123';
+    mockRefreshScores
+      .mockResolvedValueOnce(DESKTOP_SCORES)
+      .mockRejectedValueOnce(new Error('mobile PSI failed'));
+    const { GET } = await import('@/app/api/psi-refresh/route');
+    const res = await GET(makeRequest('Bearer secret123') as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.desktop).toEqual(DESKTOP_SCORES);
+    expect(body.mobile).toBeNull();
+  });
+});
+```
+
+- [ ] Run to confirm they fail:
+
+```bash
+pnpm test --run __tests__/psi-refresh-route.test.ts 2>&1 | tail -10
+```
+
+Expected: module not found errors.
+
+### Step 2: Implement the route
+
+- [ ] Create `app/api/psi-refresh/route.ts`:
+
+```typescript
+import type { NextRequest } from 'next/server';
+import { log } from '@/lib/log';
+import { refreshScores } from '@/lib/lighthouse-scores';
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || req.headers.get('authorization') !== `Bearer ${cronSecret}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const t0 = Date.now();
+  const [desktopResult, mobileResult] = await Promise.allSettled([
+    refreshScores('desktop'),
+    refreshScores('mobile'),
+  ]);
+
+  const result = {
+    desktop: desktopResult.status === 'fulfilled' ? desktopResult.value : null,
+    mobile: mobileResult.status === 'fulfilled' ? mobileResult.value : null,
+    durationMs: Date.now() - t0,
+  };
+
+  if (desktopResult.status === 'rejected') {
+    log.error('psi-refresh desktop failed', { err: desktopResult.reason });
+  }
+  if (mobileResult.status === 'rejected') {
+    log.error('psi-refresh mobile failed', { err: mobileResult.reason });
+  }
+
+  log.info('psi-refresh completed', { durationMs: result.durationMs });
+  return Response.json(result);
+}
+```
+
+### Step 3: Run tests and verify
+
+- [ ] Run:
+
+```bash
+pnpm test --run __tests__/psi-refresh-route.test.ts 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] Full suite:
+
+```bash
+pnpm test --run 2>&1 | tail -5
+```
+
+Expected: 655+ passed.
+
+### Step 4: Commit
+
+- [ ] Run:
+
+```bash
+git add app/api/psi-refresh/route.ts __tests__/psi-refresh-route.test.ts
+git commit -m "feat(cron): add psi-refresh endpoint — auth-gated desktop+mobile PSI refresh"
+```
+
+---
+
+## Task 3: `vercel.json` and `.env.example`
+
+**Files:**
+- Create: `vercel.json`
+- Modify: `.env.example`
+
+### Step 1: Create `vercel.json`
+
+- [ ] Create `vercel.json` at the repo root:
+
+```json
+{
+  "crons": [
+    {
+      "path": "/api/psi-refresh",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}
+```
+
+No other configuration — Next.js app configuration lives in `next.config.ts`. Vercel reads `vercel.json` for cron schedules. The `0 3 * * *` expression means 3:00 AM UTC every day.
+
+### Step 2: Update `.env.example`
+
+- [ ] Add to the end of `.env.example`:
+
+```
+# Vercel Cron Secret — authenticates /api/psi-refresh cron invocations.
+# Vercel automatically injects this as Authorization: Bearer <value> into cron requests.
+# Set the same value in Vercel project settings > Environment Variables.
+# Generate with: openssl rand -hex 32
+CRON_SECRET=
+```
+
+### Step 3: Verify `pnpm ci:local` passes
+
+- [ ] Run:
+
+```bash
+pnpm ci:local 2>&1 | tail -5
+```
+
+Expected: all gates pass.
+
+### Step 4: Commit
+
+- [ ] Run:
+
+```bash
+git add vercel.json .env.example
+git commit -m "feat(cron): add vercel.json cron schedule for daily psi-refresh at 03:00 UTC"
+```
+
+---
+
+## Task 4: Update `LivePerfSection` — Stacked Desktop + Mobile
+
+**Files:**
+- Modify: `components/sections/LivePerfSection/LivePerfSection.tsx`
+- Modify: `components/sections/LivePerfSection/LivePerfSection.module.css`
+- Modify: `components/sections/LivePerfSection/LivePerfSection.test.tsx`
+
+### Step 1: Update the tests first
+
+- [ ] Replace the contents of `components/sections/LivePerfSection/LivePerfSection.test.tsx`:
+
+```typescript
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const getScoresMock = vi.fn();
+vi.mock('@/lib/lighthouse-scores', () => ({
+  getScores: getScoresMock,
+  LIGHTHOUSE_FALLBACK: {
+    performance: 0,
+    accessibility: 0,
+    bestPractices: 0,
+    seo: 0,
+    fetchedAt: '—',
+  },
+}));
+
+async function renderPerfData(strategy: 'desktop' | 'mobile'): Promise<string> {
+  const { PerfData } = await import('./LivePerfSection');
+  const element = await PerfData({ strategy });
+  return renderToStaticMarkup(element);
+}
+
+afterEach(() => {
+  vi.resetModules();
+  getScoresMock.mockReset();
+});
+
+describe('LivePerfSection — fetch-error fallback', () => {
+  it('renders without throwing when getScores throws for desktop', async () => {
+    getScoresMock.mockRejectedValue(new Error('PSI API unavailable'));
+    await expect(renderPerfData('desktop')).resolves.toBeDefined();
+  });
+
+  it('renders without throwing when getScores throws for mobile', async () => {
+    getScoresMock.mockRejectedValue(new Error('PSI API unavailable'));
+    await expect(renderPerfData('mobile')).resolves.toBeDefined();
+  });
+
+  it('does not render fabricated 100 scores on fetch failure for desktop', async () => {
+    getScoresMock.mockRejectedValue(new Error('PSI API unavailable'));
+    const html = await renderPerfData('desktop');
+    expect(html).not.toContain('>100<');
+  });
+
+  it('does not render fabricated 100 scores on fetch failure for mobile', async () => {
+    getScoresMock.mockRejectedValue(new Error('PSI API unavailable'));
+    const html = await renderPerfData('mobile');
+    expect(html).not.toContain('>100<');
+  });
+});
+
+describe('LivePerfSection — strategy routing', () => {
+  it('calls getScores with desktop strategy', async () => {
+    getScoresMock.mockResolvedValue({
+      performance: 99, accessibility: 100, bestPractices: 95, seo: 100,
+      fetchedAt: '2026-05-29T03:00:00.000Z',
+    });
+    await renderPerfData('desktop');
+    expect(getScoresMock).toHaveBeenCalledWith('desktop');
+  });
+
+  it('calls getScores with mobile strategy', async () => {
+    getScoresMock.mockResolvedValue({
+      performance: 90, accessibility: 100, bestPractices: 95, seo: 100,
+      fetchedAt: '2026-05-29T03:00:00.000Z',
+    });
+    await renderPerfData('mobile');
+    expect(getScoresMock).toHaveBeenCalledWith('mobile');
+  });
+
+  it('renders the score value from getScores', async () => {
+    getScoresMock.mockResolvedValue({
+      performance: 88, accessibility: 100, bestPractices: 95, seo: 100,
+      fetchedAt: '2026-05-29T03:00:00.000Z',
+    });
+    const html = await renderPerfData('mobile');
+    expect(html).toContain('88');
+  });
+});
+```
+
+- [ ] Run to confirm failures:
+
+```bash
+pnpm test --run components/sections/LivePerfSection 2>&1 | tail -10
+```
+
+Expected: failures — `PerfData` doesn't accept `strategy` prop yet.
+
+### Step 2: Update `LivePerfSection.tsx`
+
+- [ ] Replace `components/sections/LivePerfSection/LivePerfSection.tsx` with:
+
+```typescript
+import { Suspense } from 'react';
+import { getScores, LIGHTHOUSE_FALLBACK, type LighthouseScores, type Strategy } from '@/lib/lighthouse-scores';
+import { IconLivePerf } from '../../Icons';
+import { Module } from '../../responsive/Module';
+import styles from './LivePerfSection.module.css';
+
+export async function PerfData({ strategy }: { strategy: Strategy }) {
+  const scores = await getScores(strategy).catch(() => LIGHTHOUSE_FALLBACK);
+  return <PerfBody scores={scores} strategy={strategy} />;
+}
+
+function PerfBody({ scores, strategy }: { scores: LighthouseScores; strategy: Strategy }) {
+  const isFallback = scores.fetchedAt === LIGHTHOUSE_FALLBACK.fetchedAt;
+  const cells = [
+    { label: 'PERFORMANCE', value: scores.performance },
+    { label: 'ACCESSIBILITY', value: scores.accessibility },
+    { label: 'BEST PRACTICES', value: scores.bestPractices },
+    { label: 'SEO', value: scores.seo },
+  ];
+
+  const lastCheck =
+    scores.fetchedAt && scores.fetchedAt !== '—'
+      ? new Date(scores.fetchedAt).toUTCString().replace(':00 GMT', ' UTC')
+      : '—';
+
+  return (
+    <div>
+      <div className={styles.root}>
+        {cells.map((s) => (
+          <div key={s.label} className={styles.cell}>
+            <div className={styles.pk}>{s.label}</div>
+            <div className={styles.pv}>
+              {isFallback ? '—' : s.value}
+              <span className={styles.of}>/100</span>
+            </div>
+            <div className={styles.pbar}>
+              <i style={{ width: isFallback ? '0%' : `${s.value}%` }} />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={styles.foot}>
+        <span>
+          <span className={styles.liveDot} />
+          {isFallback
+            ? 'SOURCE: PSI API unavailable'
+            : `SOURCE: PageSpeed Insights · ${strategy}`}
+        </span>
+        <span>LAST_CHECK: {lastCheck}</span>
+      </div>
+    </div>
+  );
+}
+
+function StrategyFallback({ strategy }: { strategy: string }) {
+  return (
+    <div aria-busy="true" style={{ opacity: 0.4 }}>
+      <div className={styles.root}>
+        {['PERFORMANCE', 'ACCESSIBILITY', 'BEST PRACTICES', 'SEO'].map((label) => (
+          <div key={label} className={styles.cell}>
+            <div className={styles.pk}>{label}</div>
+            <div className={styles.pv}>
+              —<span className={styles.of}>/100</span>
+            </div>
+            <div className={styles.pbar}>
+              <i style={{ width: '0%' }} />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={styles.foot}>
+        <span>
+          <span className={styles.liveDot} />
+          {strategy} · loading...
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function PerfFallback() {
+  return (
+    <>
+      <div className={styles.strategyBlock}>
+        <p className={styles.strategyLabel}>DESKTOP</p>
+        <StrategyFallback strategy="desktop" />
+      </div>
+      <div className={styles.strategyBlock}>
+        <p className={styles.strategyLabel}>MOBILE</p>
+        <StrategyFallback strategy="mobile" />
+      </div>
+    </>
+  );
+}
+
+export function LivePerfSection({ defer }: { defer?: boolean } = {}) {
+  return (
+    <Module
+      id="sec-live-perf"
+      header="LIVE_PERF.JSON"
+      mobileHeader="LIVE_PERF · LIGHTHOUSE"
+      icon={<IconLivePerf />}
+      defer={defer}
+    >
+      <Suspense fallback={<PerfFallback />}>
+        <div className={styles.strategyBlock}>
+          <p className={styles.strategyLabel}>DESKTOP</p>
+          <PerfData strategy="desktop" />
+        </div>
+        <div className={styles.strategyBlock}>
+          <p className={styles.strategyLabel}>MOBILE</p>
+          <PerfData strategy="mobile" />
+        </div>
+      </Suspense>
+    </Module>
+  );
+}
+```
+
+### Step 3: Update `LivePerfSection.module.css`
+
+- [ ] Add to the end of `components/sections/LivePerfSection/LivePerfSection.module.css` (before the final closing brace of any media query — append at file end):
+
+```css
+.strategyBlock + .strategyBlock {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--ds-color-border);
+}
+
+.strategyLabel {
+  color: var(--ds-color-text-muted);
+  font-size: var(--ds-font-size-xs);
+  letter-spacing: 0.18em;
+  margin-bottom: 10px;
+}
+```
+
+### Step 4: Run tests and verify
+
+- [ ] Run:
+
+```bash
+pnpm test --run components/sections/LivePerfSection 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] Full suite:
+
+```bash
+pnpm test --run 2>&1 | tail -5
+```
+
+Expected: 655+ passed (new tests add to total).
+
+- [ ] Full CI gate:
+
+```bash
+pnpm ci:local 2>&1 | tail -5
+```
+
+Expected: all gates pass.
+
+### Step 5: Commit
+
+- [ ] Run:
+
+```bash
+git add components/sections/LivePerfSection/
+git commit -m "feat(perf): live-perf section shows desktop + mobile lighthouse scores stacked"
+```
+
+---
+
+## Task 5: DECISIONS.md + Final Gate
+
+**Files:**
+- Modify: `DECISIONS.md`
+
+### Step 1: Add the DECISIONS.md entry
+
+- [ ] Append to `DECISIONS.md` (after the last existing entry):
+
+```markdown
+## 2026-05-29 — PSI refresh cron: desktop + mobile Lighthouse scores
+
+- **2026-05-29** — **Vercel cron added for daily PSI refresh** (`vercel.json`, `app/api/psi-refresh/route.ts`). Runs at 03:00 UTC daily. Before this, the `lh:scores` Redis key expired after 24h and the first post-expiry visitor triggered a live PSI fetch (8s timeout, fallback to zeroes on failure). The cron ensures the cache is always warm. Auth: `Authorization: Bearer {CRON_SECRET}` — Vercel injects this automatically; any other caller gets 401. _Reversible: remove `vercel.json` crons entry; cache-on-demand resumes._
+- **2026-05-29** — **Lighthouse score cache split by strategy**: `lh:scores` (old, single key) replaced by `lh:scores:desktop` and `lh:scores:mobile`. TTL raised from 24h to 25h to survive a single missed cron run. The old `lh:scores` key orphans in Redis and expires on its own. `getScores()` default arg (`'desktop'`) preserves backward compat for `/api/lighthouse`. `refreshScores(strategy)` added for cron use — always fetches, throws on failure, caller handles via `Promise.allSettled`. _Reversible: revert `lib/lighthouse-scores.ts`; the old single-key behavior returns._
+- **2026-05-29** — **LIVE_PERF.JSON section now shows both desktop and mobile scores** in a stacked layout. Two `<PerfData strategy>` RSC instances inside one `<Suspense>` — React fetches both in parallel. Each fails independently (mobile fallback does not block desktop display). No client island added. _Reversible: revert `LivePerfSection.tsx` to single-strategy render._
+```
+
+### Step 2: Final CI gate
+
+- [ ] Run:
+
+```bash
+pnpm ci:local 2>&1 | tail -5
+```
+
+Expected: all gates pass.
+
+- [ ] Count tests to confirm additions landed:
+
+```bash
+pnpm test --run 2>&1 | grep "Tests "
+```
+
+Expected: more than 655 tests (new lighthouse-scores + psi-refresh-route tests added).
+
+### Step 3: Commit
+
+- [ ] Run:
+
+```bash
+git add DECISIONS.md
+git commit -m "docs(decisions): document psi refresh cron, strategy split, stacked live-perf display"
+```
+
+---
+
+## Failure-Mode Checklist
+
+Generated from `thinking-inversion` before writing this plan:
+
+| Bug class | Mitigation in plan |
+|---|---|
+| `CRON_SECRET` unset → any caller can trigger expensive PSI fetches | Handler fails closed: `if (!cronSecret) return 401` |
+| Mobile PSI failure blocks desktop cache write | `Promise.allSettled` — each is independent |
+| Cache key collision between old `lh:scores` and new `lh:scores:desktop` | Different key names; old key orphans and expires |
+| `getScores()` callers break when `strategy` param added | Default arg `strategy: Strategy = 'desktop'` preserves compat |
+| `refreshScores` silently returns fallback instead of throwing | `refreshScores` throws; `getScores` catches — tested separately |
+| 25h TTL not long enough if cron skips two days | TTL is per-strategy; two skipped days = 48h; fallback shows `—` after 25h — acceptable |
+| Suspense boundary shows partial state if one strategy loads faster | Both `PerfData` inside one `<Suspense>` — all-or-nothing display |
+| Test mocks `getScores` globally, breaks strategy routing tests | Tests use `vi.resetModules()` + per-strategy mock expectations |
+| Lint-token-boundary flag on `.strategyBlock` CSS if using raw hex or magic values | New CSS uses only `var(--ds-color-*)` tokens and `px` values consistent with existing file |

--- a/docs/superpowers/specs/2026-05-29-psi-refresh-cron-design.md
+++ b/docs/superpowers/specs/2026-05-29-psi-refresh-cron-design.md
@@ -1,0 +1,165 @@
+# Design: PSI Refresh Cron — Live Desktop + Mobile Lighthouse Scores
+
+**Date:** 2026-05-29
+**Branch:** `feat/psi-refresh-cron`
+**Reversibility:** High — reverts to cache-on-demand by removing the cron handler, `vercel.json` crons entry, and reverting `lib/lighthouse-scores.ts`.
+
+---
+
+## Problem
+
+`lib/lighthouse-scores.ts` fetches PSI on cache miss (Redis TTL = 24h). No proactive refresh exists. The first visitor after TTL expiry triggers a live PSI call with an 8-second timeout — visible latency or a `—` fallback if PSI is slow. The `LIVE_PERF.JSON` section shows desktop scores only; mobile scores are absent despite the site having mobile-specific budgets.
+
+---
+
+## Scope
+
+- Proactive daily PSI refresh via Vercel cron (eliminates user-triggered live fetches)
+- Desktop + mobile scores, independently cached, independently fallback-safe
+- `LIVE_PERF.JSON` section updated to display both strategies in a stacked layout
+- No UI interaction (no toggle) — pure RSC, both rows rendered at SSR time
+
+Out of scope: real-time scores, on-demand refresh endpoint, visitor-triggered fallback removal.
+
+---
+
+## Section 1: `lib/lighthouse-scores.ts` — Strategy Extension
+
+### Changes
+
+Add `Strategy = 'desktop' | 'mobile'` type. Split the single Redis key into:
+- `lh:scores:desktop`
+- `lh:scores:mobile`
+
+Bump TTL from `86_400` (24h) to `90_000` (25h) — survives a single missed cron run without a cache miss.
+
+Extract the PSI fetch + cache-write into `fetchAndCache(strategy)` (private). Two public exports:
+
+```typescript
+export async function getScores(strategy: Strategy = 'desktop'): Promise<LighthouseScores>
+```
+Cache-first. On miss calls `fetchAndCache`. Falls back to `LIGHTHOUSE_FALLBACK` on any error. Default arg preserves backward compat with `/api/lighthouse`.
+
+```typescript
+export async function refreshScores(strategy: Strategy): Promise<LighthouseScores>
+```
+Always calls `fetchAndCache`. Throws on PSI failure (cron handler catches per-strategy via `Promise.allSettled`). Used only by the cron handler — forces a fresh fetch even if cache is warm.
+
+`fetchAndCache` fires the PSI URL with `&strategy={desktop|mobile}`, parses the response identically for both, writes to `lh:scores:{strategy}` with TTL 25h (fire-and-forget), returns scores.
+
+### Key: old `lh:scores` key
+
+The old desktop key (`lh:scores`) becomes orphaned in Redis after deploy. It will expire on its own TTL. No migration needed.
+
+---
+
+## Section 2: `app/api/psi-refresh/route.ts` — Cron Handler
+
+GET-only route. Auth check is the first and only gate:
+
+```
+Authorization: Bearer {CRON_SECRET}
+```
+
+Vercel injects this header automatically for cron invocations when `CRON_SECRET` is set in the project environment. Any other caller gets `401`. If `CRON_SECRET` is unset, all requests get `401` (fail-closed on missing secret).
+
+After auth:
+1. `Promise.allSettled([refreshScores('desktop'), refreshScores('mobile')])`
+2. Log result summary with `durationMs`
+3. Return `{ desktop: scores|null, mobile: scores|null, durationMs }` as JSON
+
+Each strategy is independent — a mobile PSI failure does not block the desktop write.
+
+Does NOT use `defineHandler` — that helper is for rate-limited, body-parsed JSON routes. Cron route has no body and no rate-limit concern (it's auth-gated).
+
+---
+
+## Section 3: `vercel.json` — Cron Schedule
+
+```json
+{
+  "crons": [
+    {
+      "path": "/api/psi-refresh",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}
+```
+
+3 AM UTC daily — low-traffic window, ahead of EU morning. Vercel cron documentation: the `schedule` field uses standard cron syntax. Vercel automatically injects `Authorization: Bearer {CRON_SECRET}` if the env var is set.
+
+---
+
+## Section 4: `LivePerfSection.tsx` + CSS — Stacked Desktop + Mobile
+
+### Component changes
+
+`PerfData` gains a required `strategy: Strategy` prop. `PerfBody` gains the same prop (for the footer label). The strategy label replaces the current "SOURCE: PageSpeed Insights · cached daily" suffix — instead each block footer reads `SOURCE: PSI · desktop` or `SOURCE: PSI · mobile`.
+
+`LivePerfSection` renders two `PerfData` instances inside one `<Suspense>`:
+
+```tsx
+<Suspense fallback={<PerfFallback />}>
+  <div className={styles.strategyBlock}>
+    <p className={styles.strategyLabel}>DESKTOP</p>
+    <PerfData strategy="desktop" />
+  </div>
+  <div className={styles.strategyBlock}>
+    <p className={styles.strategyLabel}>MOBILE</p>
+    <PerfData strategy="mobile" />
+  </div>
+</Suspense>
+```
+
+React fetches both in parallel (RSC concurrent rendering). Each fails independently — if mobile PSI returns fallback, the mobile block shows `—` while desktop shows real scores.
+
+`PerfFallback` renders two skeleton blocks (DESKTOP + MOBILE) to avoid layout shift on Suspense hydration.
+
+### CSS additions (`.module.css`)
+
+```css
+.strategyBlock + .strategyBlock {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--ds-color-border);
+}
+
+.strategyLabel {
+  color: var(--ds-color-text-muted);
+  font-size: var(--ds-font-size-xs);
+  letter-spacing: 0.18em;
+  margin-bottom: 10px;
+}
+```
+
+---
+
+## Section 5: Env + Docs
+
+`.env.example` gains:
+```
+# Vercel Cron Secret — authenticates /api/psi-refresh.
+# Vercel injects this automatically into cron requests.
+# Set in Vercel project settings. Generate: openssl rand -hex 32
+CRON_SECRET=
+```
+
+`DECISIONS.md` entry: cron architecture decision, TTL rationale, strategy split.
+
+---
+
+## Testing
+
+| What | Where | How |
+|---|---|---|
+| `getScores` cache-hit path | `__tests__/lighthouse-scores.test.ts` | Mock Redis `get` returns cached value; assert PSI fetch not called |
+| `getScores` cache-miss path | same | Mock Redis `get` returns null; mock PSI fetch; assert write |
+| `getScores` fallback on PSI error | same | Mock PSI fetch to throw; assert returns `LIGHTHOUSE_FALLBACK` |
+| `refreshScores` always fetches | same | Mock Redis `get`; assert PSI fetch called regardless |
+| `refreshScores` throws on error | same | Mock PSI fetch to throw; assert rejects |
+| Cron handler: 401 on bad auth | `__tests__/psi-refresh-route.test.ts` | Call GET with wrong/missing Bearer; assert 401 |
+| Cron handler: 200 with both strategies | same | Mock `refreshScores`; assert both called; assert JSON shape |
+| Cron handler: partial failure | same | Mock mobile `refreshScores` to throw; assert desktop data present, mobile null |
+| `PerfData` desktop + mobile render | `LivePerfSection.test.tsx` | Two `getScores` calls with correct strategy args |
+| Existing fallback tests | `__tests__/lighthouse-fallback.test.ts` | No change — `LIGHTHOUSE_FALLBACK` shape unchanged |

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Add `variant` prop to `Module` (`'green'` | default) to split section body backgrounds: 10 data/interactive sections keep the full `rgba(0,255,65,0.05)` signal tint; all other narrative sections default to `transparent`
- 10 sections pass `variant="green"`: AiMetrics, Projects, PerfReceipts, NpmStack, ManPage, LivePerf, SysHealth, Guitar, DawMixer, Contact
- `Field::placeholder` set to `--ds-color-signal` at 0.6 opacity — replaces browser-default gray on contact form inputs

## Type of change

- [ ] `feat` — new functionality
- [x] `refactor` — no behaviour change
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement
- [ ] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes (655 tests, lint, typecheck, content, naming gates all green)
- [x] No new behaviour — CSS-only variant split + placeholder colour; no test surface change required

## Visual changes

- [x] Desktop (1280×720) checked via Playwright MCP — green sections show `rgba(0,255,65,0.05)` tint; non-green sections transparent; contact form placeholders vibrant green
- [x] Mobile (375×812) checked via Playwright MCP — same treatment, consistent across breakpoints
- [x] No visual regressions introduced

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — all values use `--ds-color-signal` or existing rgba literals already present in the file
- [x] No `use client` added without necessity (RSC drift) — Module is RSC; variant prop is server-evaluated, zero browser JS
- [x] Bundle size impact assessed (`pnpm bundle-check`) — no movement (variant resolves to static class string at SSR)
- [x] A11y impact considered — placeholder contrast 5.59:1 clears WCAG AA; body text on all backgrounds ≥18:1; axe-core gate passes
- [x] ADR added to `DECISIONS.md` if this changes architecture — no architecture change; variant prop is a presentational option on an existing component