### PR TITLE
refactor(ui): data-attribute variant pattern — replace all className conditionals

### DIFF
--- a/__tests__/content-visibility.test.ts
+++ b/__tests__/content-visibility.test.ts
@@ -1,21 +1,20 @@
 // __tests__/content-visibility.test.ts
 // Behavioral test: verifies the below-fold deferral mechanism.
 //
-//  - The `defer` prop on a section must produce the `.cvDefer` class on the
-//    rendered <section> — proven by rendering the Module shell both ways.
+//  - The `defer` prop on a section must produce the `data-cv-defer` attribute
+//    on the rendered <details> — proven by rendering the Module shell both ways.
 //  - The page composition must mark every below-fold section with defer —
 //    proven by walking the real element tree app/page.tsx's Home() returns.
 //
-// The `.cvDefer { content-visibility: auto }` CSS rule itself is a build
-// asset; that single read carries a behavioral-test-allow tag (jsdom does not
-// evaluate stylesheet `content-visibility`, so the shipped rule's presence in
-// Module.module.css is the strongest verifiable signal).
+// The `details[data-cv-defer="true"] { content-visibility: auto }` CSS rule
+// itself is a build asset; that single read carries a behavioral-test-allow
+// tag (jsdom does not evaluate stylesheet `content-visibility`, so the shipped
+// rule's presence in Module.module.css is the strongest verifiable signal).
 
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
-import moduleStyles from '@/components/responsive/Module/Module.module.css';
 
 // Module is a pure (sync, non-async) Server Component: one <details> for every
 // viewport, no UA detection. No stub needed — it renders deterministically.
@@ -35,7 +34,7 @@ function countDeferredSections(node: unknown): number {
 }
 
 describe('content-visibility deferral', () => {
-  it('Module renders the cv-defer class only when defer is set', async () => {
+  it('Module renders data-cv-defer attribute only when defer is set', async () => {
     const { Module } = await import('@/components/responsive/Module');
     // Module is a sync Server Component — call it to obtain the element.
     const deferredEl = Module({
@@ -50,8 +49,8 @@ describe('content-visibility deferral', () => {
       defer: false,
       children: null,
     });
-    expect(renderToStaticMarkup(deferredEl)).toContain(moduleStyles.cvDefer);
-    expect(renderToStaticMarkup(eagerEl)).not.toContain(moduleStyles.cvDefer);
+    expect(renderToStaticMarkup(deferredEl)).toContain('data-cv-defer="true"');
+    expect(renderToStaticMarkup(eagerEl)).not.toContain('data-cv-defer');
   });
 
   it('app/page.tsx defers every below-fold section (>= 14)', async () => {
@@ -65,15 +64,15 @@ describe('content-visibility deferral', () => {
     expect(deferredCount).toBeGreaterThanOrEqual(14);
   });
 
-  it('Module.module.css ships the cvDefer content-visibility rule', () => {
+  it('Module.module.css ships the data-cv-defer content-visibility rule', () => {
     // behavioral-test-allow: reads the shipped stylesheet build asset; jsdom cannot evaluate content-visibility
     const moduleCss = readFileSync(
       path.resolve(__dirname, '../components/responsive/Module/Module.module.css'),
       'utf-8',
     );
-    expect(moduleCss).toContain('.cvDefer');
+    expect(moduleCss).toContain('data-cv-defer');
     expect(moduleCss).toContain('content-visibility: auto');
-    // Class-based selection replaced the brittle nth-of-type positional
+    // Attribute-based selection replaced the brittle nth-of-type positional
     // selector — guard against a regression back to positional deferral.
     expect(moduleCss).not.toMatch(/nth-of-type\(n\s*\+\s*\d+\)/);
   });

--- a/components/responsive/Module/Module.module.css
+++ b/components/responsive/Module/Module.module.css
@@ -43,8 +43,10 @@
 }
 
 /* Below-fold deferral: skip style/layout/paint until near viewport.
-   Applied via data-cv-defer attribute on the <details> element when defer=true. */
-details[data-cv-defer="true"] {
+   Applied via data-cv-defer attribute on the <details> element when defer=true.
+   WHY: .root[data-cv-defer="true"] (0,2,0) — CSS Modules requires at least one local
+   class; element-only selectors are rejected as impure. */
+.root[data-cv-defer="true"] {
   content-visibility: auto;
   /* `auto 520px`: the 14 deferred sections vary too widely for one fixed
      estimate (measured desktop 186-1837px, mobile 70-2538px).

--- a/components/responsive/Module/Module.module.css
+++ b/components/responsive/Module/Module.module.css
@@ -134,7 +134,7 @@
   transition: opacity var(--ds-duration-slow) cubic-bezier(0.32, 0, 0.67, 0);
 }
 
-.bodyContentGreen {
+.bodyContent[data-variant="green"] {
   background: rgba(0, 255, 65, 0.05);
 }
 

--- a/components/responsive/Module/Module.module.css
+++ b/components/responsive/Module/Module.module.css
@@ -43,11 +43,8 @@
 }
 
 /* Below-fold deferral: skip style/layout/paint until near viewport.
-   Applied via the .cvDefer class set in app/page.tsx on modules at index >= 4
-   (ProjectsSection onward — Readme/Shell/ManPage/Now are the four above-fold candidates).
-   Class-based selection survives section reorderings and hero-variant changes without
-   silent regression (replacing the previous nth-of-type positional approach). */
-.cvDefer {
+   Applied via data-cv-defer attribute on the <details> element when defer=true. */
+details[data-cv-defer="true"] {
   content-visibility: auto;
   /* `auto 520px`: the 14 deferred sections vary too widely for one fixed
      estimate (measured desktop 186-1837px, mobile 70-2538px).

--- a/components/responsive/Module/Module.test.tsx
+++ b/components/responsive/Module/Module.test.tsx
@@ -1,0 +1,36 @@
+// components/responsive/Module/Module.test.tsx
+// Behavioral tests for Module — pure Server Component.
+// Uses renderToStaticMarkup + DOMParser (same pattern as HeroStats.test.tsx)
+// to avoid jsdom hydration overhead for an RSC with no client effects.
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { Module } from './Module';
+
+function render(element: React.ReactElement) {
+  const html = renderToStaticMarkup(element);
+  const container = new DOMParser().parseFromString(html, 'text/html').body;
+  return { container };
+}
+
+describe('Module', () => {
+  it('passes data-variant="green" to bodyContent when variant="green"', async () => {
+    const { container } = render(
+      <Module id="test" header="TEST" variant="green">
+        content
+      </Module>,
+    );
+    const el = container.querySelector('[data-variant="green"]');
+    expect(el).not.toBeNull();
+  });
+
+  it('renders no data-variant attribute when variant is not set', async () => {
+    const { container } = render(
+      <Module id="test" header="TEST">
+        content
+      </Module>,
+    );
+    const el = container.querySelector('[data-variant]');
+    expect(el).toBeNull();
+  });
+});

--- a/components/responsive/Module/Module.test.tsx
+++ b/components/responsive/Module/Module.test.tsx
@@ -33,4 +33,15 @@ describe('Module', () => {
     const el = container.querySelector('[data-variant]');
     expect(el).toBeNull();
   });
+
+  it('adds data-cv-defer attribute when defer=true, no cvDefer class', async () => {
+    const { container } = render(
+      <Module id="test" header="TEST" defer>
+        content
+      </Module>,
+    );
+    const details = container.querySelector('details');
+    expect(details?.getAttribute('data-cv-defer')).toBe('true');
+    expect(details?.className).not.toContain('cvDefer');
+  });
 });

--- a/components/responsive/Module/Module.tsx
+++ b/components/responsive/Module/Module.tsx
@@ -34,7 +34,7 @@ export type ModuleProps = {
   defer?: boolean | undefined;
   /**
    * "green": full rgba(0,255,65,0.05) tint — for data-heavy/interactive sections.
-   * Default: SESSION_REPORT-style subtle gradient — for narrative/context sections.
+   * Default (omitted): transparent background — for narrative/context sections.
    */
   variant?: 'green';
   children: ReactNode;

--- a/components/responsive/Module/Module.tsx
+++ b/components/responsive/Module/Module.tsx
@@ -76,13 +76,7 @@ export function Module({
         {/* bodyInner: grid item — no padding so 0fr collapses to true 0.
             bodyContent: padding+color wrapper inside the overflow:hidden clip. */}
         <div className={styles.bodyInner}>
-          <div
-            className={
-              variant === 'green'
-                ? `${styles.bodyContent} ${styles.bodyContentGreen}`
-                : styles.bodyContent
-            }
-          >
+          <div className={styles.bodyContent} data-variant={variant}>
             {children}
           </div>
         </div>

--- a/components/responsive/Module/Module.tsx
+++ b/components/responsive/Module/Module.tsx
@@ -52,7 +52,7 @@ export function Module({
   return (
     <details
       id={id}
-      className={defer ? `${styles.root} ${styles.cvDefer}` : styles.root}
+      className={styles.root}
       // Always open: see the file header. A section can still be collapsed by
       // tapping its summary on mobile.
       open

--- a/components/sections/DawMixerSection/DawMixerDesktop.tsx
+++ b/components/sections/DawMixerSection/DawMixerDesktop.tsx
@@ -50,7 +50,9 @@ function ChannelDesktop({ ch }: { ch: DawMixerChannel }) {
   const isMaster = ch.id === 'MASTER';
   return (
     <div
-      className={`${s.channelRow} ${ch.focused ? s.channelFocused : ''} ${isMaster ? s.channelMaster : ''}`}
+      className={s.channelRow}
+      data-focused={ch.focused || undefined}
+      data-channel={isMaster ? 'master' : undefined}
       data-testid={`channel-${ch.id}`}
     >
       <div className={s.colId}>

--- a/components/sections/DawMixerSection/DawMixerDesktop.tsx
+++ b/components/sections/DawMixerSection/DawMixerDesktop.tsx
@@ -56,7 +56,9 @@ function ChannelDesktop({ ch }: { ch: DawMixerChannel }) {
       data-testid={`channel-${ch.id}`}
     >
       <div className={s.colId}>
-        <span className={isMaster ? s.masterBadge : s.channelBadge}>{ch.id}</span>
+        <span className={s.channelBadge} data-channel={isMaster ? 'master' : undefined}>
+          {ch.id}
+        </span>
         <span className={s.channelSubName}>{ch.name}</span>
         <div className={s.clipBar} aria-hidden="true">
           <div className={s.clipFill} style={{ width: `${ch.faderPct}%` }} />

--- a/components/sections/DawMixerSection/DawMixerSection.module.css
+++ b/components/sections/DawMixerSection/DawMixerSection.module.css
@@ -20,15 +20,20 @@
   letter-spacing: 0.04em;
   flex-shrink: 0;
 }
-.masterBadge {
-  border: 1px solid var(--ds-color-signal);
+.channelBadge[data-channel="master"] {
+  border-color: var(--ds-color-signal);
   padding: 2px 8px;
-  font-size: var(--ds-font-size-xs);
-  font-family: var(--ds-font-family-mono);
   font-weight: 700;
   color: var(--ds-color-signal);
   letter-spacing: 0.12em;
-  flex-shrink: 0;
+}
+.mxId[data-channel="master"] {
+  border-color: var(--ds-color-signal);
+  padding: 2px 8px;
+  font-weight: 700;
+  color: var(--ds-color-signal);
+  letter-spacing: 0.12em;
+  background: transparent;
 }
 .dbValue {
   font-weight: 700;
@@ -319,7 +324,8 @@
 
 /* ─── Desktop font overrides for shared classes ─────────────────────────── */
 .root .channelBadge,
-.root .masterBadge {
+.root .channelBadge[data-channel="master"],
+.root .mxId[data-channel="master"] {
   font-size: var(--ds-font-size-sm);
 }
 

--- a/components/sections/DawMixerSection/DawMixerSection.module.css
+++ b/components/sections/DawMixerSection/DawMixerSection.module.css
@@ -188,10 +188,10 @@
   padding: 14px 18px;
   position: relative;
 }
-.channelFocused {
+.channelRow[data-focused] {
   background: color-mix(in srgb, var(--ds-color-signal) 6%, transparent);
 }
-.channelFocused::before {
+.channelRow[data-focused]::before {
   content: "";
   position: absolute;
   left: 0;
@@ -201,7 +201,7 @@
   background: var(--ds-color-signal);
   box-shadow: 0 0 10px var(--ds-color-signal);
 }
-.channelMaster {
+.channelRow[data-channel="master"] {
   background: linear-gradient(
     90deg,
     color-mix(in srgb, var(--ds-color-signal) 8%, transparent),
@@ -236,11 +236,11 @@
   background: var(--ds-color-signal);
   opacity: 0.85;
 }
-.channelFocused .clipBar {
+.channelRow[data-focused] .clipBar {
   border-color: var(--ds-color-signal);
   box-shadow: 0 0 6px color-mix(in srgb, var(--ds-color-signal) 40%, transparent);
 }
-.channelFocused .clipFill {
+.channelRow[data-focused] .clipFill {
   opacity: 1;
 }
 
@@ -258,8 +258,8 @@
   letter-spacing: 0.04em;
   line-height: 1;
 }
-.channelFocused .trackName,
-.channelMaster .trackName {
+.channelRow[data-focused] .trackName,
+.channelRow[data-channel="master"] .trackName {
   color: var(--ds-color-signal);
 }
 .trackDesc {
@@ -387,10 +387,10 @@
   flex-direction: column;
   gap: 12px;
 }
-.channelCardFocused {
+.channelCard[data-focused] {
   background: color-mix(in srgb, var(--ds-color-signal) 7%, transparent);
 }
-.channelCardFocused::before {
+.channelCard[data-focused]::before {
   content: "";
   position: absolute;
   left: 0;
@@ -400,7 +400,7 @@
   background: var(--ds-color-signal);
   box-shadow: 0 0 10px var(--ds-color-signal);
 }
-.channelCardMaster {
+.channelCard[data-channel="master"] {
   background: linear-gradient(
     180deg,
     color-mix(in srgb, var(--ds-color-signal) 6%, transparent),
@@ -427,7 +427,7 @@
   white-space: nowrap;
   flex-shrink: 0;
 }
-.channelCardFocused .mxId {
+.channelCard[data-focused] .mxId {
   color: var(--ds-color-signal);
   border-color: var(--ds-color-signal);
   background: color-mix(in srgb, var(--ds-color-signal) 10%, transparent);
@@ -443,8 +443,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.channelCardFocused .mxName,
-.channelCardMaster .mxName {
+.channelCard[data-focused] .mxName,
+.channelCard[data-channel="master"] .mxName {
   color: var(--ds-color-signal);
 }
 .mxDb {

--- a/components/sections/DawMixerSection/DawMixerSection.test.tsx
+++ b/components/sections/DawMixerSection/DawMixerSection.test.tsx
@@ -57,7 +57,13 @@ describe('DawMixerSection — desktop', () => {
   it('CH 02 has focused class (active channel indicator)', async () => {
     const doc = await renderDesktop();
     const ch02 = doc.querySelector('[data-testid="channel-CH 02"]');
-    expect(ch02?.className).toContain('channelFocused');
+    expect(ch02?.hasAttribute('data-focused')).toBe(true);
+  });
+
+  it('MASTER channel row has data-channel="master"', async () => {
+    const doc = await renderDesktop();
+    const masterRow = doc.querySelector('[data-testid="channel-MASTER"]');
+    expect(masterRow?.getAttribute('data-channel')).toBe('master');
   });
 
   it('MASTER row shows LUFS data', async () => {

--- a/components/sections/DawMixerSection/DawMixerSection.tsx
+++ b/components/sections/DawMixerSection/DawMixerSection.tsx
@@ -160,7 +160,9 @@ function ChannelMobile({ ch }: { ch: DawMixerChannel }) {
       data-testid={`channel-mobile-${ch.id}`}
     >
       <div className={s.mxHead}>
-        <span className={isMaster ? s.masterBadge : s.mxId}>{ch.id}</span>
+        <span className={s.mxId} data-channel={isMaster ? 'master' : undefined}>
+          {ch.id}
+        </span>
         <span className={s.mxName}>{ch.name}</span>
         <div className={s.mxDb}>
           <span className={s.dbValue}>{ch.db}</span>

--- a/components/sections/DawMixerSection/DawMixerSection.tsx
+++ b/components/sections/DawMixerSection/DawMixerSection.tsx
@@ -154,7 +154,9 @@ function ChannelMobile({ ch }: { ch: DawMixerChannel }) {
   const isMaster = ch.id === 'MASTER';
   return (
     <div
-      className={`${s.channelCard} ${ch.focused ? s.channelCardFocused : ''} ${isMaster ? s.channelCardMaster : ''}`}
+      className={s.channelCard}
+      data-focused={ch.focused || undefined}
+      data-channel={isMaster ? 'master' : undefined}
       data-testid={`channel-mobile-${ch.id}`}
     >
       <div className={s.mxHead}>

--- a/components/sections/GuitarSection/GuitarSection.module.css
+++ b/components/sections/GuitarSection/GuitarSection.module.css
@@ -203,16 +203,6 @@
 .queueCount {
   color: var(--ds-color-signal);
 }
-.infActive {
-  display: grid;
-  grid-template-columns: 36px 1fr auto;
-  gap: 10px;
-  align-items: center;
-  margin-bottom: 9px;
-  color: var(--ds-color-signal);
-  font-weight: 700;
-  font-size: var(--ds-font-size-xs);
-}
 .infItem {
   display: grid;
   grid-template-columns: 36px 1fr auto;
@@ -221,6 +211,10 @@
   margin-bottom: 9px;
   color: var(--ds-color-text-body);
   font-size: var(--ds-font-size-xs);
+}
+.infItem[data-active] {
+  color: var(--ds-color-signal);
+  font-weight: 700;
 }
 .infRank {
   color: var(--ds-color-text-muted);
@@ -377,7 +371,6 @@
 .root .camHeader,
 .root .camCaption,
 .root .influencesHeader,
-.root .infActive,
 .root .infItem,
 .root .infRank,
 .root .nowObsessing {

--- a/components/sections/GuitarSection/GuitarSection.test.tsx
+++ b/components/sections/GuitarSection/GuitarSection.test.tsx
@@ -60,7 +60,7 @@ describe('GuitarSection — influences (desktop)', () => {
 
   it('renders John Mayer as the active (▶) influence', async () => {
     const doc = await renderDesktop();
-    const active = doc.querySelector('[data-testid="guitar-desktop"] [class*="infActive"]');
+    const active = doc.querySelector('[data-testid="guitar-desktop"] [data-active]');
     expect(active?.textContent).toContain('John Mayer');
   });
 

--- a/components/sections/GuitarSection/GuitarSection.tsx
+++ b/components/sections/GuitarSection/GuitarSection.tsx
@@ -79,7 +79,7 @@ function InfluencesList({
         <span>{'// SHUFFLE OFF'}</span>
       </div>
       {influences.map((inf) => (
-        <div key={inf.rank} className={inf.active ? s.infActive : s.infItem}>
+        <div key={inf.rank} className={s.infItem} data-active={inf.active || undefined}>
           <span className={s.infRank}>
             {inf.active ? '▶ ' : ''}
             {String(inf.rank).padStart(2, '0')}

--- a/components/sections/PerfReceiptsSection/PerfReceiptsSection.module.css
+++ b/components/sections/PerfReceiptsSection/PerfReceiptsSection.module.css
@@ -76,12 +76,12 @@
   margin: 6px 0 8px;
 }
 
-.deltaHero {
+.delta[data-featured] {
   font-size: var(--ds-font-size-heading-xl);
 }
 
 @media (max-width: 900px) {
-  .deltaHero {
+  .delta[data-featured] {
     font-size: var(--ds-font-size-heading-xl);
   }
 }
@@ -107,7 +107,7 @@
   padding-top: 10px;
 }
 
-.receiptHero .deltaHero {
+.receiptHero .delta[data-featured] {
   font-size: var(--ds-font-size-heading-xl);
 }
 
@@ -119,8 +119,8 @@
   .delta {
     font-size: var(--ds-font-size-heading-sm);
   }
-  /* Higher specificity (0,2,0) beats .delta (0,1,0) */
-  .receiptHero .deltaHero {
+  /* Specificity: .receiptHero .delta[data-featured] = 0,3,0 beats .delta[data-featured] = 0,2,0 */
+  .receiptHero .delta[data-featured] {
     font-size: var(--ds-font-size-heading-md);
   }
 }

--- a/components/sections/PerfReceiptsSection/PerfReceiptsSection.test.tsx
+++ b/components/sections/PerfReceiptsSection/PerfReceiptsSection.test.tsx
@@ -28,9 +28,9 @@ describe('PerfReceiptsSection — hero data-featured variant', () => {
 
   it('non-hero delta elements do not carry data-featured', async () => {
     const doc = await renderSection();
-    // All delta elements: the hero one carries data-featured, the rest do not.
-    // Verify at least one delta element exists without the attribute.
-    const withoutFeatured = doc.querySelectorAll('p:not([data-featured])');
-    expect(withoutFeatured.length).toBeGreaterThan(0);
+    // Query delta elements specifically (not all paragraphs) to avoid matching
+    // company/note/metric <p> elements that are never delta candidates.
+    const nonFeaturedDeltas = doc.querySelectorAll('[class*="delta"]:not([data-featured])');
+    expect(nonFeaturedDeltas.length).toBeGreaterThan(0);
   });
 });

--- a/components/sections/PerfReceiptsSection/PerfReceiptsSection.test.tsx
+++ b/components/sections/PerfReceiptsSection/PerfReceiptsSection.test.tsx
@@ -1,0 +1,36 @@
+// components/sections/PerfReceiptsSection/PerfReceiptsSection.test.tsx
+// Behavioral tests: hero receipt carries data-featured attribute instead of a
+// concatenated CSS class — the attribute drives the CSS variant selector
+// .delta[data-featured] in PerfReceiptsSection.module.css.
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+async function renderSection(): Promise<Document> {
+  const { PerfReceiptsSection } = await import('./PerfReceiptsSection');
+  const html = renderToStaticMarkup(createElement(PerfReceiptsSection));
+  return new DOMParser().parseFromString(html, 'text/html');
+}
+
+describe('PerfReceiptsSection — hero data-featured variant', () => {
+  it('adds data-featured attribute to the hero delta value', async () => {
+    const doc = await renderSection();
+    const featured = doc.querySelector('[data-featured]');
+    expect(featured).not.toBeNull();
+  });
+
+  it('renders exactly one element with data-featured', async () => {
+    const doc = await renderSection();
+    const featured = doc.querySelectorAll('[data-featured]');
+    expect(featured.length).toBe(1);
+  });
+
+  it('non-hero delta elements do not carry data-featured', async () => {
+    const doc = await renderSection();
+    // All delta elements: the hero one carries data-featured, the rest do not.
+    // Verify at least one delta element exists without the attribute.
+    const withoutFeatured = doc.querySelectorAll('p:not([data-featured])');
+    expect(withoutFeatured.length).toBeGreaterThan(0);
+  });
+});

--- a/components/sections/PerfReceiptsSection/PerfReceiptsSection.tsx
+++ b/components/sections/PerfReceiptsSection/PerfReceiptsSection.tsx
@@ -33,7 +33,9 @@ function ReceiptCard({
           metric
         )}
       </p>
-      <p className={hero ? `${styles.delta} ${styles.deltaHero}` : styles.delta}>{delta}</p>
+      <p className={styles.delta} data-featured={hero || undefined}>
+        {delta}
+      </p>
       <p className={styles.company}>{company}</p>
       <p className={styles.note}>{note}</p>
     </li>

--- a/components/sections/ResponsibilitiesSection/ResponsibilitiesSection.module.css
+++ b/components/sections/ResponsibilitiesSection/ResponsibilitiesSection.module.css
@@ -41,7 +41,7 @@
   color: var(--ds-color-text-body);
 }
 
-.root .file.crit {
+.root .file[data-highlight] {
   color: var(--ds-color-signal);
   font-weight: 700;
 }

--- a/components/sections/ResponsibilitiesSection/ResponsibilitiesSection.test.tsx
+++ b/components/sections/ResponsibilitiesSection/ResponsibilitiesSection.test.tsx
@@ -1,0 +1,28 @@
+// components/sections/ResponsibilitiesSection/ResponsibilitiesSection.test.tsx
+// Behavioral tests: renders responsibilities list, highlight attribute on critical items.
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+async function render(): Promise<Document> {
+  const { ResponsibilitiesSection } = await import('./ResponsibilitiesSection');
+  const html = renderToStaticMarkup(createElement(ResponsibilitiesSection));
+  return new DOMParser().parseFromString(html, 'text/html');
+}
+
+describe('ResponsibilitiesSection — highlight attribute', () => {
+  it('adds data-highlight to highlighted responsibility lines', async () => {
+    const doc = await render();
+    const highlighted = doc.querySelector('[data-highlight]');
+    expect(highlighted).not.toBeNull();
+  });
+
+  it('non-highlighted items do not carry data-highlight', async () => {
+    const doc = await render();
+    const all = doc.querySelectorAll('[class*="file"]');
+    const withAttr = doc.querySelectorAll('[data-highlight]');
+    expect(withAttr.length).toBeGreaterThan(0);
+    expect(withAttr.length).toBeLessThan(all.length);
+  });
+});

--- a/components/sections/ResponsibilitiesSection/ResponsibilitiesSection.tsx
+++ b/components/sections/ResponsibilitiesSection/ResponsibilitiesSection.tsx
@@ -28,7 +28,7 @@ export function ResponsibilitiesSection({ defer }: { defer?: boolean } = {}) {
               {'  '}
               <span className={styles.group}>{r.group}</span>
               {'  '}
-              <span className={`${styles.file}${r.highlight ? ` ${styles.crit}` : ''}`}>
+              <span className={styles.file} data-highlight={r.highlight || undefined}>
                 {r.name}
               </span>
               {'\n'}


### PR DESCRIPTION
## Summary

- Replace 7 className ternary/template-literal patterns with `data-*` attribute + CSS attribute selectors across Module, DawMixer, GuitarSection, PerfReceipts, and ResponsibilitiesSection — visual branching moves entirely into CSS, TSX className becomes unconditional on every migrated element
- Eliminate `.bodyContentGreen`, `.cvDefer`, `.deltaHero`, `.crit`, `.channelFocused`, `.channelMaster`, `.channelCardFocused`, `.channelCardMaster`, `.masterBadge`, `.infActive` — 10 class names removed from the codebase
- Fix `content-visibility.test.ts` which referenced the old `.cvDefer` class; fix CSS Modules impure-selector error (`details[data-cv-defer]` → `.root[data-cv-defer]`)

## Type of change

- [ ] `feat` — new functionality
- [ ] `fix` — bug fix
- [x] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [ ] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes — 664 tests, 97 test files, lint + typecheck + content + naming gates all green
- [x] New behaviour covered by tests — Module (3), PerfReceipts (3), Responsibilities (2), DawMixer (14), Guitar (15), content-visibility (3); all updated to assert on `data-*` attributes instead of class names

## Visual changes

- [x] Desktop (1280×720) checked via Playwright MCP — PerfReceipts hero delta larger, Guitar active influence signal green, DawMixer CH 02 focused accent + MASTER gradient + signal badge all intact
- [x] Mobile (375×812) checked via Playwright MCP — DawMixer mobile focused channel accent verified; consistent with desktop
- [x] No visual regressions introduced

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — all values use existing design tokens or rgba literals already in the codebase
- [x] No `use client` added without necessity (RSC drift) — all modified components are RSC; zero new client boundaries
- [x] Bundle size impact assessed — no movement; `data-*` attributes resolve at SSR, zero JS shipped
- [x] A11y impact considered — accessibility-tester agent: zero findings; no ARIA conflicts, no contrast changes, WCAG 2.1 AA maintained
- [x] ADR added to `DECISIONS.md` if this changes architecture — no architecture change; presentational pattern only