### PR TITLE
ci(visual): Argos CI visual regression evaluation (D1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,11 @@ LANGFUSE_ENABLED=
 LANGFUSE_SECRET_KEY=sk-lf-...
 LANGFUSE_PUBLIC_KEY=pk-lf-...
 LANGFUSE_BASEURL=https://cloud.langfuse.com
+
+# Argos CI — visual regression testing service (D1 evaluation).
+# When set, the ArgosReporter in playwright.config.ts uploads screenshots from
+# visual regression runs to Argos for cross-environment comparison.
+# Absent = Argos upload skipped; local/CI pixel-diff tests still run normally.
+# Get from: app.argos-ci.com > your project > Settings > ARGOS_TOKEN
+# Set as a GitHub repo secret (Settings > Secrets > Actions > New repository secret).
+ARGOS_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,9 +591,13 @@ jobs:
       - if: inputs.update_visual_baselines != 'true'
         name: Run visual regression
         run: pnpm playwright test --project=${{ matrix.project }} tests/visual/visual.spec.ts
+        env:
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
       - if: inputs.update_visual_baselines == 'true'
         name: Regenerate visual baselines (workflow_dispatch only)
         run: pnpm playwright test --project=${{ matrix.project }} tests/visual/visual.spec.ts --update-snapshots
+        env:
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
       - if: inputs.update_visual_baselines == 'true'
         name: Upload regenerated visual baselines
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,
@@ -37,7 +37,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedVariables": "error",
         "noUnusedImports": "error",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "not dead"
   ],
   "devDependencies": {
+    "@argos-ci/playwright": "^7.0.6",
     "@axe-core/playwright": "^4.11.3",
     "@biomejs/biome": "^2.4.16",
     "@commitlint/cli": "^21.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,10 @@
+import ArgosReporter from '@argos-ci/playwright/reporter';
+import type { ReporterDescription } from 'playwright/test';
 import { defineConfig, devices } from 'playwright/test';
+
+// Playwright's ReporterDescription only allows strings as the first tuple element,
+// but it accepts class constructors at runtime. Cast to satisfy the strict type.
+const argosEntry = [[ArgosReporter]] as unknown as ReporterDescription[];
 
 export default defineConfig({
   testDir: './tests',
@@ -6,7 +12,10 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : 1,
-  reporter: process.env.GITHUB_ACTIONS ? [['github'], ['list']] : 'list',
+  reporter: [
+    ...(process.env.GITHUB_ACTIONS ? ([['github'], ['list']] as const) : ([['list']] as const)),
+    ...(process.env.ARGOS_TOKEN ? argosEntry : []),
+  ],
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,4 @@
-import ArgosReporter from '@argos-ci/playwright/reporter';
-import type { ReporterDescription } from 'playwright/test';
 import { defineConfig, devices } from 'playwright/test';
-
-// Playwright's ReporterDescription only allows strings as the first tuple element,
-// but it accepts class constructors at runtime. Cast to satisfy the strict type.
-const argosEntry = [[ArgosReporter]] as unknown as ReporterDescription[];
 
 export default defineConfig({
   testDir: './tests',
@@ -14,7 +8,7 @@ export default defineConfig({
   workers: process.env.CI ? 2 : 1,
   reporter: [
     ...(process.env.GITHUB_ACTIONS ? ([['github'], ['list']] as const) : ([['list']] as const)),
-    ...(process.env.ARGOS_TOKEN ? argosEntry : []),
+    ...(process.env.ARGOS_TOKEN ? [['@argos-ci/playwright/reporter'] as [string]] : []),
   ],
   use: {
     baseURL: 'http://localhost:3000',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@argos-ci/playwright':
+        specifier: ^7.0.6
+        version: 7.0.6
       '@axe-core/playwright':
         specifier: ^4.11.3
         version: 4.11.3(playwright-core@1.60.0)
@@ -210,6 +213,26 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@argos-ci/api-client@0.22.0':
+    resolution: {integrity: sha512-CzMDTZXT6+0fvtfdwUwu4NIzyS0zhEJoGd/0m/zSFIK+kXvWIJyIl/eZqyGRr5+B6OPFR1cRtOI9pX5w3u4i8A==}
+    engines: {node: '>=22.0.0'}
+
+  '@argos-ci/browser@6.1.0':
+    resolution: {integrity: sha512-9R508bY/qzZ14ZkddAfRL9Oq5K9gPRlLaUfv3SFGoKGSWlufsHnVvTTeHAAO9kLIXxJ3/bTW0MxLQD93Fs9DqQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@argos-ci/core@6.1.1':
+    resolution: {integrity: sha512-8W8GYhnMAaxr3HKydsCmLN21PSExEMI+iBerzEoFXRlKgFilCg3HssVBxLKCXrhh/IBPYyQnspgRll5n9QsNeQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@argos-ci/playwright@7.0.6':
+    resolution: {integrity: sha512-meL47krLuWXtxonMqsZ35PQKJnvvSCbtV/lkLJL5j4qMynmZwHRDP6T9vVyF9jmBIZIb3aKvGW/GYiEdV6xv2w==}
+    engines: {node: '>=22.0.0'}
+
+  '@argos-ci/util@4.0.0':
+    resolution: {integrity: sha512-2yrJr81OVpa2TkvSjzGZlGv6SVqZcxF62AVk6M79aZ7nXkwWFg3tjA8awbFwn2mODI67gkP5FarAD29bzx3P3w==}
+    engines: {node: '>=22.0.0'}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1180,6 +1203,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@opentelemetry/api-logs@0.219.0':
     resolution: {integrity: sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==}
     engines: {node: '>=8.0.0'}
@@ -1998,6 +2033,10 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2198,6 +2237,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convict@6.2.5:
+    resolution: {integrity: sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==}
+    engines: {node: '>=6'}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
@@ -2538,6 +2581,10 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
@@ -2555,6 +2602,9 @@ packages:
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -2578,6 +2628,10 @@ packages:
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
@@ -2675,6 +2729,10 @@ packages:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -2860,6 +2918,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@2.0.0:
     resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
     engines: {node: '>=4'}
@@ -2868,8 +2930,20 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
@@ -3120,6 +3194,9 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
   lodash.groupby@4.6.0:
     resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
@@ -3255,6 +3332,10 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   metaviewport-parser@0.3.0:
     resolution: {integrity: sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==}
 
@@ -3366,6 +3447,10 @@ packages:
 
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -3553,6 +3638,12 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
+
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
@@ -3564,6 +3655,10 @@ packages:
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
+
+  p-retry@8.0.0:
+    resolution: {integrity: sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==}
+    engines: {node: '>=22'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -3638,6 +3733,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -3725,6 +3824,9 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -3849,6 +3951,10 @@ packages:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -3870,6 +3976,9 @@ packages:
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rxjs@6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -4177,6 +4286,10 @@ packages:
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -4539,6 +4652,10 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4608,6 +4725,41 @@ snapshots:
       standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.4.3
+
+  '@argos-ci/api-client@0.22.0':
+    dependencies:
+      debug: 4.4.3
+      openapi-fetch: 0.17.0
+      p-retry: 8.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@argos-ci/browser@6.1.0': {}
+
+  '@argos-ci/core@6.1.1':
+    dependencies:
+      '@argos-ci/api-client': 0.22.0
+      '@argos-ci/util': 4.0.0
+      convict: 6.2.5
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      mime-types: 3.0.2
+      sharp: 0.34.5
+      tmp: 0.2.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@argos-ci/playwright@7.0.6':
+    dependencies:
+      '@argos-ci/browser': 6.1.0
+      '@argos-ci/core': 6.1.1
+      '@argos-ci/util': 4.0.0
+      chalk: 5.6.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@argos-ci/util@4.0.0': {}
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -5182,8 +5334,7 @@ snapshots:
     dependencies:
       hono: 4.12.25
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -5570,6 +5721,18 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.9':
     optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@opentelemetry/api-logs@0.219.0':
     dependencies:
@@ -6355,6 +6518,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.37
@@ -6551,6 +6718,11 @@ snapshots:
       meow: 13.2.0
 
   convert-source-map@2.0.0: {}
+
+  convict@6.2.5:
+    dependencies:
+      lodash.clonedeep: 4.5.0
+      yargs-parser: 20.2.9
 
   cookie-signature@1.0.7: {}
 
@@ -6954,6 +7126,14 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-safe-stringify@2.1.1: {}
 
   fast-sha256@1.3.0: {}
@@ -6969,6 +7149,10 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fd-slicer@1.1.0:
     dependencies:
@@ -6987,6 +7171,10 @@ snapshots:
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   finalhandler@1.3.2:
     dependencies:
@@ -7094,6 +7282,10 @@ snapshots:
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@7.2.3:
     dependencies:
@@ -7351,11 +7543,21 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@2.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
   is-hexadecimal@2.0.1: {}
+
+  is-network-error@1.3.2: {}
+
+  is-number@7.0.0: {}
 
   is-obj@2.0.0: {}
 
@@ -7616,6 +7818,8 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  lodash.clonedeep@4.5.0: {}
+
   lodash.groupby@4.6.0: {}
 
   lodash@4.18.1: {}
@@ -7843,6 +8047,8 @@ snapshots:
   merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge2@1.4.1: {}
 
   metaviewport-parser@0.3.0: {}
 
@@ -8112,6 +8318,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -8260,6 +8471,12 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
+  openapi-typescript-helpers@0.1.0: {}
+
   opener@1.5.2: {}
 
   p-limit@2.3.0:
@@ -8269,6 +8486,10 @@ snapshots:
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
+
+  p-retry@8.0.0:
+    dependencies:
+      is-network-error: 1.3.2
 
   p-try@2.2.0: {}
 
@@ -8344,6 +8565,8 @@ snapshots:
   pend@1.2.0: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -8466,6 +8689,8 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.1
+
+  queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
 
@@ -8638,6 +8863,8 @@ snapshots:
       onetime: 2.0.1
       signal-exit: 3.0.7
 
+  reusify@1.1.0: {}
+
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
@@ -8676,6 +8903,10 @@ snapshots:
       - supports-color
 
   run-async@2.4.1: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   rxjs@6.6.7:
     dependencies:
@@ -8793,7 +9024,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -9057,6 +9287,10 @@ snapshots:
       tldts-core: 7.4.2
 
   tmp@0.2.7: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   toidentifier@1.0.1: {}
 
@@ -9372,6 +9606,8 @@ snapshots:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
+
+  yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
 

--- a/tests/e2e/_helpers/snapshot.ts
+++ b/tests/e2e/_helpers/snapshot.ts
@@ -29,7 +29,7 @@ const SNAPSHOT_TIMEOUT_MS = 30_000;
 // 'visible' only disables render-skipping; on-screen rendering is identical.
 // Also removes <nextjs-portal> (dev cache/build indicator) which appears
 // non-deterministically and would cause baseline drift if left in the DOM.
-async function revealDeferredContent(page: Page): Promise<void> {
+export async function revealDeferredContent(page: Page): Promise<void> {
   await page.evaluate(() => {
     for (const el of document.querySelectorAll('[data-cv-defer]')) {
       (el as HTMLElement).style.setProperty('content-visibility', 'visible');

--- a/tests/visual/visual.spec.ts
+++ b/tests/visual/visual.spec.ts
@@ -56,10 +56,10 @@ test.describe('visual regression', () => {
     // inset:-50%), so Playwright's mask would paint the whole capture #FF00FF.
     // DOM removal is the only reliable strip; product behavior is untouched.
     await stripVolatileChrome(mockedPage);
-    await snapshotLocator(mockedPage, heroSection, 'hero-above-fold.png');
     if (process.env.ARGOS_TOKEN) {
       await argosScreenshot(mockedPage, 'hero-above-fold', { element: heroSection });
     }
+    await snapshotLocator(mockedPage, heroSection, 'hero-above-fold.png');
   });
 
   test('2 — contact section matches baseline', async ({ mockedPage }) => {
@@ -71,15 +71,15 @@ test.describe('visual regression', () => {
     // Strip volatile chrome (canvas + CRT overlays). See test 1 for why
     // masking the CRT layers is insufficient.
     await stripVolatileChrome(mockedPage);
+    if (process.env.ARGOS_TOKEN) {
+      await argosScreenshot(mockedPage, 'contact-section', { element: contactSection });
+    }
     // maxDiffPixels disables the ratio gate (snapshotLocator AND logic) and sets
     // an absolute budget. 3000px absorbs the 1px sub-pixel height oscillation
     // (486↔487px) on Chromium mobile without masking real layout regressions.
     await snapshotLocator(mockedPage, contactSection, 'contact-section.png', {
       maxDiffPixels: 3000,
     });
-    if (process.env.ARGOS_TOKEN) {
-      await argosScreenshot(mockedPage, 'contact-section', { element: contactSection });
-    }
   });
 
   test('3 — shell + ask form (idle) matches baseline', async ({ mockedPage }) => {
@@ -107,10 +107,10 @@ test.describe('visual regression', () => {
       if (ph) (ph as HTMLElement).style.visibility = 'hidden';
     });
     await stripVolatileChrome(mockedPage);
-    await snapshotLocator(mockedPage, shellSection, 'shell-idle.png');
     if (process.env.ARGOS_TOKEN) {
       await argosScreenshot(mockedPage, 'shell-idle', { element: shellSection });
     }
+    await snapshotLocator(mockedPage, shellSection, 'shell-idle.png');
   });
 
   test('4 — shell + ask form (mid-stream) matches baseline', async ({ mockedPage }) => {
@@ -173,10 +173,10 @@ test.describe('visual regression', () => {
       if (ph) (ph as HTMLElement).style.visibility = 'hidden';
     });
     await stripVolatileChrome(mockedPage);
-    await snapshotLocator(mockedPage, shellSection, 'shell-mid-stream.png');
     if (process.env.ARGOS_TOKEN) {
       await argosScreenshot(mockedPage, 'shell-mid-stream', { element: shellSection });
     }
+    await snapshotLocator(mockedPage, shellSection, 'shell-mid-stream.png');
   });
 
   test('5 — hottest takes section matches baseline', async ({ mockedPage }) => {
@@ -203,9 +203,9 @@ test.describe('visual regression', () => {
     });
     await mockedPage.evaluate(() => document.fonts.ready);
     await stripVolatileChrome(mockedPage);
-    await snapshotLocator(mockedPage, hottest, 'hottest-takes-section.png');
     if (process.env.ARGOS_TOKEN) {
       await argosScreenshot(mockedPage, 'hottest-takes-section', { element: hottest });
     }
+    await snapshotLocator(mockedPage, hottest, 'hottest-takes-section.png');
   });
 });

--- a/tests/visual/visual.spec.ts
+++ b/tests/visual/visual.spec.ts
@@ -10,7 +10,7 @@
 import { argosScreenshot } from '@argos-ci/playwright';
 import { expect, test } from '../e2e/_helpers/fixtures';
 import { stripVolatileChrome } from '../e2e/_helpers/mask-volatile';
-import { snapshotLocator } from '../e2e/_helpers/snapshot';
+import { revealDeferredContent, snapshotLocator } from '../e2e/_helpers/snapshot';
 
 // Bump the per-test timeout above the snapshot's stability timeout (30s in
 // snapshot.ts). Default test timeout is 30s, so a 30s snapshot stability
@@ -57,6 +57,7 @@ test.describe('visual regression', () => {
     // DOM removal is the only reliable strip; product behavior is untouched.
     await stripVolatileChrome(mockedPage);
     if (process.env.ARGOS_TOKEN) {
+      await revealDeferredContent(mockedPage);
       await argosScreenshot(mockedPage, 'hero-above-fold', { element: heroSection });
     }
     await snapshotLocator(mockedPage, heroSection, 'hero-above-fold.png');
@@ -72,6 +73,7 @@ test.describe('visual regression', () => {
     // masking the CRT layers is insufficient.
     await stripVolatileChrome(mockedPage);
     if (process.env.ARGOS_TOKEN) {
+      await revealDeferredContent(mockedPage);
       await argosScreenshot(mockedPage, 'contact-section', { element: contactSection });
     }
     // maxDiffPixels disables the ratio gate (snapshotLocator AND logic) and sets
@@ -108,6 +110,7 @@ test.describe('visual regression', () => {
     });
     await stripVolatileChrome(mockedPage);
     if (process.env.ARGOS_TOKEN) {
+      await revealDeferredContent(mockedPage);
       await argosScreenshot(mockedPage, 'shell-idle', { element: shellSection });
     }
     await snapshotLocator(mockedPage, shellSection, 'shell-idle.png');
@@ -174,6 +177,7 @@ test.describe('visual regression', () => {
     });
     await stripVolatileChrome(mockedPage);
     if (process.env.ARGOS_TOKEN) {
+      await revealDeferredContent(mockedPage);
       await argosScreenshot(mockedPage, 'shell-mid-stream', { element: shellSection });
     }
     await snapshotLocator(mockedPage, shellSection, 'shell-mid-stream.png');
@@ -204,6 +208,7 @@ test.describe('visual regression', () => {
     await mockedPage.evaluate(() => document.fonts.ready);
     await stripVolatileChrome(mockedPage);
     if (process.env.ARGOS_TOKEN) {
+      await revealDeferredContent(mockedPage);
       await argosScreenshot(mockedPage, 'hottest-takes-section', { element: hottest });
     }
     await snapshotLocator(mockedPage, hottest, 'hottest-takes-section.png');

--- a/tests/visual/visual.spec.ts
+++ b/tests/visual/visual.spec.ts
@@ -7,6 +7,7 @@
 // the Playwright-default sibling directory per spec file). Second+ runs diff
 // against the baseline. CI enforces maxDiffPixelRatio=0.01.
 
+import { argosScreenshot } from '@argos-ci/playwright';
 import { expect, test } from '../e2e/_helpers/fixtures';
 import { stripVolatileChrome } from '../e2e/_helpers/mask-volatile';
 import { snapshotLocator } from '../e2e/_helpers/snapshot';
@@ -56,6 +57,9 @@ test.describe('visual regression', () => {
     // DOM removal is the only reliable strip; product behavior is untouched.
     await stripVolatileChrome(mockedPage);
     await snapshotLocator(mockedPage, heroSection, 'hero-above-fold.png');
+    if (process.env.ARGOS_TOKEN) {
+      await argosScreenshot(mockedPage, 'hero-above-fold', { element: heroSection });
+    }
   });
 
   test('2 — contact section matches baseline', async ({ mockedPage }) => {
@@ -73,6 +77,9 @@ test.describe('visual regression', () => {
     await snapshotLocator(mockedPage, contactSection, 'contact-section.png', {
       maxDiffPixels: 3000,
     });
+    if (process.env.ARGOS_TOKEN) {
+      await argosScreenshot(mockedPage, 'contact-section', { element: contactSection });
+    }
   });
 
   test('3 — shell + ask form (idle) matches baseline', async ({ mockedPage }) => {
@@ -101,6 +108,9 @@ test.describe('visual regression', () => {
     });
     await stripVolatileChrome(mockedPage);
     await snapshotLocator(mockedPage, shellSection, 'shell-idle.png');
+    if (process.env.ARGOS_TOKEN) {
+      await argosScreenshot(mockedPage, 'shell-idle', { element: shellSection });
+    }
   });
 
   test('4 — shell + ask form (mid-stream) matches baseline', async ({ mockedPage }) => {
@@ -164,6 +174,9 @@ test.describe('visual regression', () => {
     });
     await stripVolatileChrome(mockedPage);
     await snapshotLocator(mockedPage, shellSection, 'shell-mid-stream.png');
+    if (process.env.ARGOS_TOKEN) {
+      await argosScreenshot(mockedPage, 'shell-mid-stream', { element: shellSection });
+    }
   });
 
   test('5 — hottest takes section matches baseline', async ({ mockedPage }) => {
@@ -191,5 +204,8 @@ test.describe('visual regression', () => {
     await mockedPage.evaluate(() => document.fonts.ready);
     await stripVolatileChrome(mockedPage);
     await snapshotLocator(mockedPage, hottest, 'hottest-takes-section.png');
+    if (process.env.ARGOS_TOKEN) {
+      await argosScreenshot(mockedPage, 'hottest-takes-section', { element: hottest });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Wire `@argos-ci/playwright` reporter and `argosScreenshot()` calls to enable cross-environment visual comparison (macOS vs Linux CI baselines) as part of the D1 evaluation
- Argos captures run before local `snapshotLocator()` assertions so cross-env diffs don't abort the upload; `revealDeferredContent()` called first so deferred sections aren't captured as solid black
- Reporter uses string-path form (`'@argos-ci/playwright/reporter'`) -- no class import or type cast needed; integration is no-op when `ARGOS_TOKEN` is absent
- **Biome 2.5.0 migration (bundled):** PR #114 esbuild override resolved `@biomejs/biome` to 2.5.0 in the lockfile; `pnpm biome migrate --write` updated the schema URL and renamed `recommended: true` to `preset: "recommended"` per the Biome 2.5 deprecation -- required to keep `pnpm check` clean, committed in e09de70

## Type of change

- [ ] `feat` -- new functionality
- [ ] `fix` -- bug fix
- [ ] `refactor` -- no behaviour change
- [ ] `perf` -- performance improvement
- [x] `chore` / `ci` / `docs` -- non-functional

## Test plan

- [x] `pnpm ci:local` passes
- [x] New behaviour covered by tests
- 5-agent battery (code-review, a11y, security, perf, deps) all PASS across all 4 commits
- D1.3 decisive criterion: create Argos account at app.argos-ci.com, add `ARGOS_TOKEN` as GitHub repo secret, open a test PR and verify Argos PR comment appears; check macOS vs Linux diffs

## Visual changes

No UI changes. Test infrastructure only -- `argosScreenshot()` calls are gated by `ARGOS_TOKEN` and are a no-op in local dev and CI without the secret.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary)
- [x] No `use client` added without necessity (RSC drift)
- [x] Bundle size impact assessed (`pnpm bundle-check`) -- devDependency only, zero bundle impact
- [x] A11y impact considered (axe-core will gate in CI) -- test infra only, no HTML changes
- [x] ADR added to `DECISIONS.md` if this changes architecture -- D1.4 ADR pending D1.3 evaluation results