### PR TITLE
ci(dx): auto-request copilot review on pr open for non-fork prs

### DIFF
--- a/.github/workflows/copilot-review-request.yml
+++ b/.github/workflows/copilot-review-request.yml
@@ -6,10 +6,12 @@ on:
 
 jobs:
   copilot-review:
-    # Non-fork PRs only — fork PRs don't have access to secrets and the
-    # reviewer assignment would fail silently or with a misleading error.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Non-fork PRs only; skip drafts (ready_for_review will re-trigger when promoted).
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/copilot-review-request.yml
+++ b/.github/workflows/copilot-review-request.yml
@@ -1,0 +1,24 @@
+name: Request Copilot Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  copilot-review:
+    # Non-fork PRs only — fork PRs don't have access to secrets and the
+    # reviewer assignment would fail silently or with a misleading error.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request Copilot review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "$PR_NUMBER" \
+            --add-reviewer copilot-pull-request-reviewer \
+            --repo "$REPO"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/copilot-review-request.yml`: triggers on `pull_request: [opened, reopened, ready_for_review]` and calls `gh pr edit --add-reviewer copilot-pull-request-reviewer` so Copilot reviews fire automatically on every PR open, whether opened via `gh pr create`, the GitHub UI, or the MCP tool.
- Non-fork guard (`head.repo.full_name == repository`) ensures the job skips fork PRs where `GITHUB_TOKEN` has no write access and reviewer assignment would fail.
- `${{ }}` interpolation kept out of `run:` scripts — PR number and repo name passed via `env:` variables (`PR_NUMBER`, `REPO`) per safe injection-prevention practice.

## Type of change

- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes (CI-only change; no code changed)
- [x] 5-agent battery (code-reviewer, security-auditor, accessibility-tester, performance-engineer, dependency-manager) — all PASS, no findings
- [x] Security audit: no untrusted input in `run:`, fork guard confirmed correct, permissions minimal (`pull-requests: write` only), no injection vectors

## Visual changes

N/A — no UI changes.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary)
- [x] No `use client` added without necessity (RSC drift)
- [x] Bundle size impact assessed — CI-only, no impact
- [x] A11y impact considered — CI-only, no impact
- [x] ADR added to `DECISIONS.md` if this changes architecture