### PR TITLE
feat(healthz): per-IP rate limiting and 5s in-process PSI cache

### DIFF
--- a/__tests__/healthz.test.ts
+++ b/__tests__/healthz.test.ts
@@ -1,18 +1,30 @@
+import type { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const redisMockGet = vi.fn();
+const limitMock = vi.fn();
+const getClientIpMock = vi.fn(() => '1.2.3.4');
 
 vi.mock('@/lib/rate-limit', () => ({
   getRedis: vi.fn(() => ({ get: redisMockGet })),
+  getHealthzLimit: vi.fn(() => ({ limit: limitMock })),
+  getClientIp: getClientIpMock,
 }));
 
 const FRESH_TIMESTAMP = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago
 const STALE_TIMESTAMP = new Date(Date.now() - 26 * 60 * 60 * 1000).toISOString(); // 26h ago
 
+function makeMockRequest(): NextRequest {
+  return new Request('http://localhost/api/healthz') as unknown as NextRequest;
+}
+
 describe('GET /api/healthz', () => {
   beforeEach(() => {
     vi.resetModules();
     redisMockGet.mockReset();
+    limitMock.mockReset();
+    limitMock.mockResolvedValue({ success: true }); // default: allow
+    getClientIpMock.mockReturnValue('1.2.3.4');
   });
 
   afterEach(() => {
@@ -24,7 +36,7 @@ describe('GET /api/healthz', () => {
     redisMockGet.mockResolvedValue(FRESH_TIMESTAMP);
 
     const { GET } = await import('@/app/api/healthz/route');
-    const res = await GET();
+    const res = await GET(makeMockRequest());
 
     expect(res.status).toBe(200);
     expect(res.headers.get('Cache-Control')).toBe('no-store');
@@ -39,7 +51,7 @@ describe('GET /api/healthz', () => {
     redisMockGet.mockResolvedValue('not-a-date');
 
     const { GET } = await import('@/app/api/healthz/route');
-    const res = await GET();
+    const res = await GET(makeMockRequest());
 
     expect(res.status).toBe(503);
     const body = (await res.json()) as { status: string; sha: string; psiLastRun: string | null };
@@ -52,7 +64,7 @@ describe('GET /api/healthz', () => {
     redisMockGet.mockResolvedValue(STALE_TIMESTAMP);
 
     const { GET } = await import('@/app/api/healthz/route');
-    const res = await GET();
+    const res = await GET(makeMockRequest());
 
     expect(res.status).toBe(503);
     const body = (await res.json()) as { status: string; sha: string; psiLastRun: string | null };
@@ -65,7 +77,7 @@ describe('GET /api/healthz', () => {
     redisMockGet.mockResolvedValue(null);
 
     const { GET } = await import('@/app/api/healthz/route');
-    const res = await GET();
+    const res = await GET(makeMockRequest());
 
     expect(res.status).toBe(503);
     const body = (await res.json()) as { status: string; sha: string; psiLastRun: string | null };
@@ -79,11 +91,51 @@ describe('GET /api/healthz', () => {
     redisMockGet.mockRejectedValue(new Error('connection refused'));
 
     const { GET } = await import('@/app/api/healthz/route');
-    const res = await GET();
+    const res = await GET(makeMockRequest());
 
     expect(res.status).toBe(503);
     const body = (await res.json()) as { status: string; sha: string; psiLastRun: null };
     expect(body.status).toBe('degraded');
     expect(body.psiLastRun).toBeNull();
+  });
+
+  it('returns 429 with Retry-After header when rate limit is exceeded', async () => {
+    vi.stubEnv('VERCEL_GIT_COMMIT_SHA', 'abc1234');
+    limitMock.mockResolvedValue({ success: false });
+
+    const { GET } = await import('@/app/api/healthz/route');
+    const res = await GET(makeMockRequest());
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('60');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    expect(redisMockGet).not.toHaveBeenCalled();
+  });
+
+  it('allows request and returns health status when rate limiter throws (fail-open)', async () => {
+    vi.stubEnv('VERCEL_GIT_COMMIT_SHA', 'abc1234');
+    limitMock.mockRejectedValue(new Error('Redis down'));
+    redisMockGet.mockResolvedValue(FRESH_TIMESTAMP);
+
+    const { GET } = await import('@/app/api/healthz/route');
+    const res = await GET(makeMockRequest());
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('ok');
+  });
+
+  it('reads psiLastRun from in-process cache on second request within TTL', async () => {
+    vi.stubEnv('VERCEL_GIT_COMMIT_SHA', 'abc1234');
+    redisMockGet.mockResolvedValue(FRESH_TIMESTAMP);
+
+    const { GET } = await import('@/app/api/healthz/route');
+    // First call — cold cache, hits Redis
+    await GET(makeMockRequest());
+    // Second call — warm cache, must NOT hit Redis again
+    const res = await GET(makeMockRequest());
+
+    expect(res.status).toBe(200);
+    expect(redisMockGet).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from 'next/server';
+import { log } from '@/lib/log';
 import { getClientIp, getHealthzLimit, getRedis } from '@/lib/rate-limit';
 
 // WHY: PSI cron runs daily; 25h window allows for schedule drift before marking stale.
@@ -23,8 +24,8 @@ export async function GET(req: NextRequest): Promise<Response> {
         headers: { 'Cache-Control': 'no-store', 'Retry-After': '60' },
       });
     }
-  } catch {
-    // fail-open: a rate-limit outage must not take down the health endpoint
+  } catch (err) {
+    log.warn('healthz rate-limit unavailable, allowing request', { err });
   }
 
   let psiLastRun: string | null = null;

--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,16 +1,44 @@
-import { getRedis } from '@/lib/rate-limit';
+import type { NextRequest } from 'next/server';
+import { getClientIp, getHealthzLimit, getRedis } from '@/lib/rate-limit';
 
 // WHY: PSI cron runs daily; 25h window allows for schedule drift before marking stale.
 const PSI_STALE_MS = 25 * 60 * 60 * 1000;
+const PSI_CACHE_TTL_MS = 5_000;
 
-export async function GET(): Promise<Response> {
+// WHY: per-instance cache — each Fluid Compute instance has its own 5s window.
+// Multiple warm instances may each make one Redis read per 5s burst; this is
+// acceptable and collapses per-instance burst reads without a shared cache layer.
+let _psiCache: { psiLastRun: string | null; cachedAt: number } | null = null;
+
+export async function GET(req: NextRequest): Promise<Response> {
   const sha = process.env.VERCEL_GIT_COMMIT_SHA || 'local';
+
+  // Rate limit — fail-open on Redis error so the monitoring endpoint stays available.
+  try {
+    const ip = getClientIp(req);
+    const { success } = await getHealthzLimit().limit(ip);
+    if (!success) {
+      return new Response('Too Many Requests', {
+        status: 429,
+        headers: { 'Cache-Control': 'no-store', 'Retry-After': '60' },
+      });
+    }
+  } catch {
+    // fail-open: a rate-limit outage must not take down the health endpoint
+  }
 
   let psiLastRun: string | null = null;
   let status: 'ok' | 'degraded' = 'ok';
 
   try {
-    psiLastRun = await getRedis().get<string>('meta:psi-last-run');
+    const now = Date.now();
+    if (_psiCache && now - _psiCache.cachedAt < PSI_CACHE_TTL_MS) {
+      psiLastRun = _psiCache.psiLastRun;
+    } else {
+      psiLastRun = await getRedis().get<string>('meta:psi-last-run');
+      _psiCache = { psiLastRun, cachedAt: now };
+    }
+
     if (!psiLastRun) {
       status = 'degraded';
     } else {

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -37,6 +37,19 @@ export function getContactLimit(): Ratelimit {
   return _contactLimit;
 }
 
+let _healthzLimit: Ratelimit | undefined;
+
+export function getHealthzLimit(): Ratelimit {
+  if (!_healthzLimit) {
+    _healthzLimit = new Ratelimit({
+      redis: getRedis(),
+      limiter: Ratelimit.slidingWindow(120, '1 m'),
+      prefix: 'rl:healthz',
+    });
+  }
+  return _healthzLimit;
+}
+
 let _errorLogLimit: Ratelimit | undefined;
 
 export function getErrorLogLimit(): Ratelimit {


### PR DESCRIPTION
## Summary

- Add per-IP sliding-window rate limit (120 req/min) to `GET /api/healthz` via `getHealthzLimit()` in `lib/rate-limit.ts`; returns 429 with `Retry-After: 60` header on exhaustion
- Add 5s in-process TTL cache (`_psiCache`) for the `meta:psi-last-run` Redis read, collapsing per-instance burst reads by ~10x at 120 req/min; cache is per-Fluid-Compute-instance (documented in WHY comment)
- Rate limiter is fail-open on Redis error (monitoring endpoint must stay available); logs `log.warn` on failure, consistent with `defineHandler` convention

## Type of change

- [x] `feat` — new functionality
- [x] `perf` — performance improvement

## Test plan

- [x] `pnpm ci:local` passes
- [x] New behaviour covered by tests

New test cases in `__tests__/healthz.test.ts`:
- 429 + `Retry-After: 60` when rate limit exhausted; PSI Redis read skipped
- Fail-open: request allowed and returns health status when rate limiter throws
- Cache hit: `redisMockGet` called exactly once across two consecutive GETs within TTL

```
Test Files  112 passed (112)
Tests  814 passed (814)
```

Runtime gates: Lighthouse desktop + mobile ✓, axe-core ✓, E2E chromium ✓

## Visual changes

No UI changes — server-only API route and lib.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary)
- [x] No `use client` added without necessity (RSC drift)
- [x] Bundle size impact assessed — server-only route, zero client bundle impact confirmed by performance agent
- [x] A11y impact considered — JSON API endpoint, no markup changes
- [x] ADR not required — this is a defence-in-depth guard on an existing endpoint, not an architecture change