### PR TITLE
ci: fix @claude OIDC auth (id-token) + Argos parallel grouping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,9 +599,14 @@ jobs:
         run: pnpm playwright test --project=${{ matrix.project }} tests/visual/visual.spec.ts
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
-          # WHY: without a shared nonce, each matrix job creates a separate Argos build.
-          # The PR check then compares the mobile build (4 screenshots, hero skipped)
-          # against the desktop reference (5 screenshots) → spurious "4 added, 5 removed".
+          # WHY: the two visual matrix jobs (chromium desktop = 5 shots; chromium-mobile
+          # = 4, hero skipped) must MERGE into one Argos build. That needs all three vars:
+          # ARGOS_PARALLEL=true activates parallel mode (without it the nonce/total are
+          # ignored), the nonce groups the jobs, and the total tells Argos how many uploads
+          # to wait for. Missing the enable flag let each job upload a SEPARATE build, so
+          # whichever finished last set the commit status — mobile last produced the
+          # spurious "4 added, 5 removed" (4-shot mobile set vs the 5-shot desktop baseline).
+          ARGOS_PARALLEL: true
           ARGOS_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
           ARGOS_PARALLEL_TOTAL: ${{ strategy.job-total }}
       - if: inputs.update_visual_baselines == 'true'
@@ -609,6 +614,7 @@ jobs:
         run: pnpm playwright test --project=${{ matrix.project }} tests/visual/visual.spec.ts --update-snapshots
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+          ARGOS_PARALLEL: true
           ARGOS_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
           ARGOS_PARALLEL_TOTAL: ${{ strategy.job-total }}
       - if: inputs.update_visual_baselines == 'true'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,11 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  # id-token: write is REQUIRED by claude-code-action: it mints its GitHub App
+  # token via OIDC (setupGitHubToken -> getOidcToken). Without it the action fails
+  # fast with "Could not fetch an OIDC token". The other three scopes let it
+  # comment and push; id-token is for auth, not repo access.
+  id-token: write
   contents: write
   pull-requests: write
   issues: write


### PR DESCRIPTION
## Summary

Two CI-config fixes surfaced while bringing the @claude pilot online:

1. **`id-token: write` for the @claude action** (`claude.yml`). The pilot failed fast with `Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?` — `claude-code-action` mints its GitHub App token via OIDC, which requires this scope. The trigger wiring was already correct (the pilot fired and passed the `author_association` gate as OWNER); it just could not authenticate. Verified against failing run `27788011397`.

2. **`ARGOS_PARALLEL: true` to actually enable Argos parallel mode** (`ci.yml`). The visual matrix set `ARGOS_PARALLEL_NONCE` and `ARGOS_PARALLEL_TOTAL` but not the enable flag, so the two visual jobs (chromium desktop = 5 shots, chromium-mobile = 4, hero skipped) uploaded as SEPARATE Argos builds. Whichever finished last set the commit status, so mobile-last produced the intermittent spurious `failure: 4 added, 5 removed` (4-shot mobile vs 5-shot desktop baseline). Adding the enable flag merges them into one build vs the baseline. Verified against the Argos build API (`parallel` is a distinct boolean from `parallelTotal`/`parallelNonce`).

Both are additive; no app, runtime, or dependency surface. The author-association guard, SHA pin, `timeout-minutes`, and the other workflow scopes are unchanged.

## Type of change

- [ ] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes — pre-push verify chain ran green on this branch.
- [x] New behaviour covered by tests — N/A (CI workflow config). The id-token fix is validated against the concrete failing run `27788011397`; the Argos fix is self-validating on this PR's own CI run (it uses the updated `ci.yml`), where Argos should now resolve deterministically instead of the 4-added/5-removed race.

`gates:runtime` not run: CI-config-only change, no app or runtime surface.

## Visual changes

No UI changes. CI workflow config only. (The Argos fix changes how visual snapshots are grouped for comparison, not the snapshots themselves.)

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — N/A
- [x] No `use client` added without necessity (RSC drift) — N/A
- [x] Bundle size impact assessed (`pnpm bundle-check`) — N/A, no client surface
- [x] A11y impact considered (axe-core will gate in CI) — N/A
- [x] ADR added to `DECISIONS.md` if this changes architecture — N/A, fixes two CI-config omissions in existing workflows
