### PR TITLE
ci(claude): stop the @claude action cancelling its own review run

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,12 +18,19 @@ on:
   pull_request_review_comment:
     types: [created]
 
-# One run per comment thread; a new mention supersedes an in-flight run.
-# run_id fallback keeps the group unique for any future trigger that populates
-# neither issue.number nor pull_request.number (today both wired triggers set one).
+# One run per comment thread. cancel-in-progress is FALSE on purpose: the action
+# posts its own "working..." progress comment via its app token, which (unlike the
+# default GITHUB_TOKEN) is NOT recursion-guarded, so it fires a fresh issue_comment
+# event and a second run in this same group. With cancel-in-progress: true that
+# self-triggered run (which then skips on the author_association guard) CANCELLED
+# the run that was mid-review, so @claude could never finish — verified live:
+# run 27790106599 (the review) was cancelled 11s after the bot's comment spawned
+# run 27790115441 (the skip). Queuing the skip-run instead of cancelling lets the
+# review complete. run_id fallback keeps the group unique for any future trigger
+# that populates neither issue.number nor pull_request.number.
 concurrency:
   group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   # id-token: write is REQUIRED by claude-code-action: it mints its GitHub App


### PR DESCRIPTION
## Summary

- Sets `cancel-in-progress: false` in the `@claude` workflow's `concurrency` block. The action posts its own "working..." progress comment via its GitHub App token, which (unlike the default `GITHUB_TOKEN`) is **not** recursion-guarded — so that comment fires a fresh `issue_comment` event and a second run in the same concurrency group. With `cancel-in-progress: true`, that self-triggered run cancelled the run that was mid-review (then skipped itself on the `author_association` gate), so `@claude` authenticated and started but **never finished**.
- Verified live on #127: review run `27790106599` (actor `erikunha`) was cancelled 11s after the bot's "working..." comment spawned skip-run `27790115441` (actor `claude[bot]`). The same log confirms the `id-token` fix works — the action minted its installation token with no OIDC error.
- Queuing the self-triggered skip-run instead of cancelling lets the review complete. The skip-run dequeues in milliseconds (gated out by `author_association`), so there is no queue build-up.

Third and final fix in the @claude bring-up: auth (`id-token`, merged), Argos grouping (merged), and now this self-cancellation.

## Type of change

- [ ] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes — pre-push verify chain ran green on this branch.
- [x] New behaviour covered by tests — N/A (CI workflow concurrency). Self-validating: once merged to main, the next `@claude` comment should complete and post a real review instead of stalling at "working...".

`gates:runtime` not run: CI-config-only change, no app or runtime surface.

## Visual changes

No UI changes. CI workflow concurrency config only.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — N/A
- [x] No `use client` added without necessity (RSC drift) — N/A
- [x] Bundle size impact assessed (`pnpm bundle-check`) — N/A, no client surface
- [x] A11y impact considered (axe-core will gate in CI) — N/A
- [x] ADR added to `DECISIONS.md` if this changes architecture — N/A, fixes a CI concurrency omission
