### PR TITLE
ci(claude): add checkout step so the action can diff the PR branch

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,9 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  # actions: read lets the action read CI/workflow run results to comment on them
+  # (per the official example). Read-only — adds no write surface.
+  actions: read
 
 jobs:
   claude:
@@ -59,6 +62,14 @@ jobs:
     # 6-hour default, the runaway-billing risk the write-scoped token amplifies.
     timeout-minutes: 20
     steps:
+      # REQUIRED: gives the action a configured git repo + authenticated remote so it
+      # can fetch the PR branch and diff it. Without checkout the action authenticates
+      # but then dies on `git fetch origin <pr-branch>` / `git hash-object` (verified:
+      # run 27790671618 failed fetching docs/knowledge-base). fetch-depth: 1 matches
+      # the official example; the action deepens history itself as needed.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
       - uses: anthropics/claude-code-action@806af32823ef69c8ef357086c573a902af641307 # v1
         with:
           # Authenticated via Claude Max subscription token (no per-use API billing).


### PR DESCRIPTION
## Summary

- Adds the `actions/checkout` step (SHA-pinned `v6.0.3`, `fetch-depth: 1`) before the `@claude` action, plus `actions: read` to permissions — aligning the hand-rolled workflow with the upstream `examples/claude.yml`.
- Root cause: with no checkout step, the action authenticated but then ran git against an unconfigured repo and died: `Command failed: git fetch origin --depth=20 docs/knowledge-base` and `Failed to compute SHA ... git hash-object` (verified on run `27790671618`, #127). The checkout gives it a git repo with an authenticated remote so it can fetch the PR branch and diff it. `actions: read` lets it read CI run results, per the official example.
- Final structural gap in the @claude bring-up. The prior two fixes (`id-token` for auth, `cancel-in-progress: false` for self-cancellation) are confirmed working in the same run logs — this run authenticated and survived; it only failed on the missing checkout.

## Type of change

- [ ] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes — pre-push verify chain ran green.
- [x] New behaviour covered by tests — N/A (CI workflow). Self-validating: once merged to main, the next `@claude` comment should authenticate, survive, AND complete a real review (all three failure modes resolved).

`gates:runtime` not run: CI-config-only change, no app or runtime surface.

## Visual changes

No UI changes. CI workflow config only.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — N/A
- [x] No `use client` added without necessity (RSC drift) — N/A
- [x] Bundle size impact assessed (`pnpm bundle-check`) — N/A, no client surface
- [x] A11y impact considered (axe-core will gate in CI) — N/A
- [x] ADR added to `DECISIONS.md` if this changes architecture — N/A, aligns the workflow with the upstream example
