### PR TITLE
ci(visual): gate the Argos job on rendering changes, not on any workflow edit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,7 @@ jobs:
     outputs:
       ai: ${{ steps.check.outputs.ai }}
       app: ${{ steps.check.outputs.app }}
+      ui: ${{ steps.check.outputs.ui }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -492,6 +493,7 @@ jobs:
           if [[ "$EVENT_NAME" != "pull_request" ]]; then
             echo "ai=true" >> "$GITHUB_OUTPUT"
             echo "app=true" >> "$GITHUB_OUTPUT"
+            echo "ui=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           ai_changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- \
@@ -512,6 +514,18 @@ jobs:
           [[ -n "$app_changed" ]] \
             && echo "app=true" >> "$GITHUB_OUTPUT" \
             || echo "app=false" >> "$GITHUB_OUTPUT"
+          # `ui` = files that can change RENDERED output; gates the visual / Argos job
+          # only. Deliberately a SUBSET of `app`: it drops .github/workflows/,
+          # lighthouserc*, and the bundle-size script, which belong in `app` (they
+          # affect the build / e2e / perf gates) but cannot change a single rendered
+          # pixel. Gating Argos on `app` made workflow-only PRs run the visual suite
+          # and report spurious "N added" diffs against the baseline.
+          ui_changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- \
+            app/ components/ design-system/ lib/ content/ public/ \
+            next.config.ts playwright.config.ts package.json pnpm-lock.yaml)
+          [[ -n "$ui_changed" ]] \
+            && echo "ui=true" >> "$GITHUB_OUTPUT" \
+            || echo "ui=false" >> "$GITHUB_OUTPUT"
 
   ai-eval:
     runs-on: ubuntu-latest
@@ -554,8 +568,10 @@ jobs:
     timeout-minutes: 15
     # REQUIRED: Linux Chromium rendering is deterministic — pixel-diff comparisons
     # are stable enough to gate on. Baselines are refreshed via workflow_dispatch.
-    # Skip on PRs that touch only scripts/docs/CI — visual diffs only matter for app code.
-    if: github.event_name != 'pull_request' || needs.detect-changes.outputs.app == 'true'
+    # Skip on PRs that touch only scripts/docs/CI: visual diffs only matter for code
+    # that can change rendered output. Gated on `ui` (not `app`) so a workflow-only
+    # PR does not run the visual suite and report spurious Argos "N added" diffs.
+    if: github.event_name != 'pull_request' || needs.detect-changes.outputs.ui == 'true'
     needs: [build, detect-changes]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Fixes spurious Argos "N added, waiting for your decision" statuses on PRs that change nothing rendered. Root cause: `detect-changes.app` includes `.github/workflows/`, and `e2e-visual-chromium` (the only job that uploads to Argos) was gated on that `app` flag, despite its own comment saying it should skip CI-only PRs. So a workflow-only PR (e.g. a `claude-review.yml` change like #133) ran the full visual suite and Argos diffed it against the baseline, reporting a false "4 added".
- Adds a narrower `ui` output to `detect-changes` (a strict subset of `app` that drops `.github/workflows/`, `lighthouserc*`, and `scripts/check-bundle-size.mjs` — paths that cannot change a rendered pixel) and gates the visual job on `ui`. Workflow / CI / LHCI-config-only PRs no longer run the visual suite or produce false Argos diffs; real rendering changes still do.
- `e2e-functional` and `performance` stay on `app`, so CI changes are still validated functionally. `ui` is a strict subset of `app`, so the visual job's `needs: [build]` (gated on `app`) is always satisfied when `ui` fires. Skipping the visual job on non-rendering PRs is safe: GitHub treats a skipped required check as satisfied (the same semantics `e2e-functional`/`performance` already use).

Note on the residual "N added" itself: that is a separate, Argos-dashboard concern — the baseline on main must contain the parallel-grouped screenshot set. This PR stops the visual job from running on non-rendering PRs (the false-positive source you hit); a genuine UI PR will still compare against the baseline as normal.

## Type of change

- [ ] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes — pre-push verify chain ran green.
- [x] New behaviour covered by tests — N/A (CI gating logic). Validated by the 5-agent battery: `ui` is a correct subset of `app`, only `e2e-visual-chromium` re-gated, `ai-eval` downstream unaffected (skipped is allowed), no injection/security change. Self-validating: this PR touches only `ci.yml`, so under the new logic its own visual job should be skipped (ui=false) and no Argos status should appear.

`gates:runtime` not run: CI-config-only change, no app or runtime surface.

## Visual changes

No UI changes. CI gating logic only. (This PR changes WHEN the visual suite runs, not any snapshot.)

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — N/A
- [x] No `use client` added without necessity (RSC drift) — N/A
- [x] Bundle size impact assessed (`pnpm bundle-check`) — N/A, no client surface
- [x] A11y impact considered (axe-core will gate in CI) — N/A
- [x] ADR added to `DECISIONS.md` if this changes architecture — N/A, fixes a path-filter bug in an existing job gate
