### PR TITLE
fix(claude-review): make the reviewer publish its own review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@806af32823ef69c8ef357086c573a902af641307 # v1
+        # PR_NUMBER is exported to the action (and the model's shell) so the prompt's
+        # `gh pr comment "$PR_NUMBER"` publish step has a real value; on issue_comment
+        # the PR number is github.event.issue.number, not auto-exported otherwise.
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
         with:
           # Claude Max subscription token (no per-use API billing).
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -193,16 +198,37 @@ jobs:
               before merge but is not a ship-stopper.
             - Advisory: a worthwhile improvement the author may reasonably defer.
 
-            ## 7. Output: exactly one top-level review
+            ## 7. Publish your review yourself
 
-            Post one review containing: Executive Summary (what the PR does and your
-            confidence); Strengths (brief, only if genuine); Critical Issues; Important
-            Issues; Advisory Improvements; and a Merge Recommendation, exactly one of:
+            This action runs in automation mode and does NOT post your output for you:
+            producing text alone publishes nothing. You MUST publish with your tools,
+            targeting this PR (you know its number from the context; it is also in the
+            $PR_NUMBER environment variable):
+
+            1. FIRST, post a one-line acknowledgement so the author sees the review has
+               started:
+               gh pr comment "$PR_NUMBER" --body "Reviewing this PR; findings to follow."
+            2. Post each inline finding with the create_inline_comment tool, anchored to
+               a line this PR changed.
+            3. Post exactly ONE top-level review as a PR comment with
+               gh pr comment "$PR_NUMBER" --body "...". Wrap the markdown body in a
+               single-quoted heredoc via command substitution so backticks, quotes, and
+               newlines survive, for example:
+               gh pr comment "$PR_NUMBER" --body "$(cat <<'REVIEW'
+               <your markdown summary here>
+               REVIEW
+               )"
+
+            If you call none of these tools, nothing is posted. The top-level summary
+            contains: Executive Summary (what the PR does and your confidence); Strengths
+            (brief, only if genuine); Critical Issues; Important Issues; Advisory
+            Improvements; and a Merge Recommendation, exactly one of:
             ✅ Approve   🟡 Approve with Minor Changes   🟠 Request Changes   🔴 Reject
-            If the PR is production-ready, state that plainly. Anchor every claim to
-            file:line, and only to lines within this PR's diff.
+            State production-readiness plainly. Anchor every claim to file:line, and only
+            to lines this PR changed.
           # Tools: file reading (Read/Grep/Glob) so the review uses full repo context
           # per the prompt; the inline-comment tool (what makes this Copilot-like); and
-          # read-only gh access to the diff/PR plus a comment fallback for the summary.
+          # gh pr (diff/view to read the change, comment to PUBLISH the ack + summary,
+          # since automation mode does not auto-post the model's output).
           claude_args: >-
             --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"


### PR DESCRIPTION
## Summary

- Fixes the `/claude-review` reviewer posting **nothing**. The run on #127 completed `success` but produced 0 reviews and 0 inline comments (`No buffered inline comments` in the log). Root cause: the action runs in **automation mode** (explicit `prompt`), where it does NOT auto-post the model's output. The `@claude` mention runs in **tag mode** (no prompt), which auto-posts — which is why that one worked. `track_progress` would post in automation mode but hard-errors on the `issue_comment` trigger, so it is unavailable for an on-demand command.
- Fix: instruct the model to **publish its own review** with the tools it already has — a one-line acknowledgement comment first (the "review started" feedback we cannot get via `track_progress`), inline findings via `create_inline_comment`, and exactly one top-level summary via `gh pr comment` with a single-quoted heredoc body.
- Also exports `PR_NUMBER: ${{ github.event.issue.number }}` to the action step so the prompt's `gh pr comment "$PR_NUMBER"` has a defined value (on `issue_comment` it is not auto-exported). This was an Important review finding — the prompt asserted an env var the workflow did not set.
- No permission, trigger, or tool change: `Bash(gh pr comment:*)` and `create_inline_comment` were already in `--allowedTools`; the prompt just makes the model use them.

## Type of change

- [ ] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes — pre-push verify chain ran green.
- [x] New behaviour covered by tests — N/A (CI workflow prompt). Reviewed by the 5-agent battery (one Important caught + fixed: the undefined `$PR_NUMBER`). Self-validating: once merged, `/claude-review` on a PR should post an acknowledgement, any inline findings, and one top-level summary with a merge recommendation.

`gates:runtime` not run: CI-config-only change, no app or runtime surface.

## Visual changes

No UI changes. CI workflow prompt only.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — N/A
- [x] No `use client` added without necessity (RSC drift) — N/A
- [x] Bundle size impact assessed (`pnpm bundle-check`) — N/A, no client surface
- [x] A11y impact considered (axe-core will gate in CI) — N/A
- [x] ADR added to `DECISIONS.md` if this changes architecture — N/A, fixes the publish path of an existing workflow
