### PR TITLE
ci(claude-review): pass --repo to gh so the pre-checkout ack step works

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -57,11 +57,14 @@ jobs:
       - name: Acknowledge the review request
         env:
           GH_TOKEN: ${{ github.token }}
+          # GH_REPO + --repo: this step runs BEFORE checkout, so gh cannot infer the
+          # repo from a .git dir ("fatal: not a git repository"); name it explicitly.
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           printf "Claude Code is working…\n\nI'll analyze this and get back to you.\n\n[View job run](%s)\n" "$RUN_URL" \
-            | gh pr comment "$PR_NUMBER" --body-file -
+            | gh pr comment "$PR_NUMBER" --repo "$GH_REPO" --body-file -
       # Gives the action a configured git repo + authenticated remote to fetch and
       # diff the PR branch (omitting this fails on git fetch / git hash-object).
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -241,10 +244,11 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           if [ -s /tmp/claude-review.md ]; then
-            gh pr comment "$PR_NUMBER" --body-file /tmp/claude-review.md
+            gh pr comment "$PR_NUMBER" --repo "$GH_REPO" --body-file /tmp/claude-review.md
           else
             echo "No /tmp/claude-review.md was produced; nothing to publish."
           fi


### PR DESCRIPTION
## Summary

- Fixes the `/claude-review` job failing on its first step. The "Acknowledge the review request" step runs BEFORE `actions/checkout`, so `gh pr comment` had no `.git` directory to infer the repo from and exited 1 with `fatal: not a git repository`, killing the whole job before the review ran (verified on run 27797393955).
- Fix: add `GH_REPO: ${{ github.repository }}` and pass `--repo "$GH_REPO"` to both `gh pr comment` calls (the pre-checkout ack step and the publish step), so `gh` names the repo explicitly via the API and needs no checkout. The publish step runs after checkout so did not strictly need it, but takes the flag for consistency and checkout-independence.

No permission, secret, or scope change. `github.repository` is a GitHub-controlled `owner/repo` value (no injection).

## Type of change

- [ ] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes — pre-push verify chain ran green.
- [x] New behaviour covered by tests — N/A (CI workflow). Reviewed by the 5-agent battery (YAML valid, both gh calls fixed, no regression, security CLEAN). Self-validating: once merged, `/claude-review` should post the working comment, run the review, and publish the summary instead of dying on the first step.

`gates:runtime` not run: CI-config-only change, no app or runtime surface.

## Visual changes

No UI changes. CI workflow only.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — N/A
- [x] No `use client` added without necessity (RSC drift) — N/A
- [x] Bundle size impact assessed (`pnpm bundle-check`) — N/A, no client surface
- [x] A11y impact considered (axe-core will gate in CI) — N/A
- [x] ADR added to `DECISIONS.md` if this changes architecture — N/A, robustness fix to an existing workflow
