### PR TITLE
feat(eval): unit C-b — Monte-Carlo runner + calibration gate

### DIFF
--- a/__tests__/agent-eval-integration.test.ts
+++ b/__tests__/agent-eval-integration.test.ts
@@ -34,7 +34,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.useRealTimers();
 });
 
 describe('agent-eval integration (SDK mocked, no real Gateway call)', () => {

--- a/__tests__/agent-eval-integration.test.ts
+++ b/__tests__/agent-eval-integration.test.ts
@@ -1,0 +1,130 @@
+// __tests__/agent-eval-integration.test.ts
+// Integration smoke for the agent-eval pipeline. Mocks the `ai` SDK
+// generateText at the MODULE BOUNDARY so NO real Gateway call is made, then
+// drives the real pipeline pieces (runTarget → gradeRun → aggregateCase, and
+// runCalibration) end-to-end. This is the spec §5 acceptance:
+//   - the trivial deterministic code case (git-add-scoping) passes 5/5
+//     (passAtK=1, passHatK=1, variance=0)
+//   - the judge calibration scores known-good PASS / known-bad FAIL →
+//     agreement=1.0, passed:true
+//   - a WEAKENED target (sometimes emits the banned form) shows passHatK < 1,
+//     proving the eval discriminates a flaky prompt from a consistent one.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGenerateText } = vi.hoisted(() => ({ mockGenerateText: vi.fn() }));
+vi.mock('ai', () => ({ generateText: mockGenerateText }));
+
+import { AGENT_EVAL_CALIBRATION, type AgentEvalCalibrationItem } from '@/evals/agents/calibration';
+import { loadCases } from '@/evals/agents/load';
+import { runCalibration } from '@/lib/eval/calibration';
+import { gradeRun } from '@/lib/eval/grade';
+import { JUDGE_SYSTEM } from '@/lib/eval/judge';
+import { aggregateCase } from '@/lib/eval/montecarlo';
+import { runTarget } from '@/lib/eval/run-target';
+
+// Helper: a generateText resolution carrying text + token usage.
+function reply(text: string) {
+  return { text, usage: { inputTokens: 50, outputTokens: 10 } };
+}
+
+beforeEach(() => {
+  mockGenerateText.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('agent-eval integration (SDK mocked, no real Gateway call)', () => {
+  it('the trivial git-add-scoping code case passes 5/5 with zero variance', async () => {
+    // The target always emits a compliant, scoped staging command. A CODE
+    // grader never calls the judge, so this exercises only runTarget.
+    mockGenerateText.mockImplementation(async () => reply('git add lib/eval/montecarlo.ts'));
+
+    const cases = await loadCases();
+    const trivial = cases.find((c) => c.id === 'git-add-scoping');
+    expect(trivial).toBeDefined();
+    if (!trivial) return;
+
+    const N = 5;
+    const runResults: boolean[] = [];
+    for (let i = 0; i < N; i++) {
+      const target = await runTarget(trivial, { model: 'anthropic/claude-haiku-4-5' });
+      const verdict = await gradeRun(trivial, target.output, {
+        judgeModel: 'anthropic/claude-sonnet-4-6',
+      });
+      runResults.push(verdict.pass);
+    }
+    const stats = aggregateCase(trivial.id, runResults);
+    expect(stats.passAtK).toBe(1);
+    expect(stats.passHatK).toBe(1);
+    expect(stats.variance).toBe(0);
+    expect(stats.passes).toBe(5);
+    // a code grader must never reach the judge: every SDK call here was a target call
+    expect(mockGenerateText).toHaveBeenCalledTimes(5);
+  });
+
+  it('a WEAKENED target makes passHatK < 1 (the eval discriminates a flaky prompt)', async () => {
+    // The weakened target emits the BANNED broad form on some runs, so the code
+    // grader fails those — passAtK stays 1 but passHatK drops below 1.
+    const outputs = [
+      'git add lib/eval/montecarlo.ts', // compliant
+      'git add -A then commit', // banned → fails
+      'git add lib/eval/grade.ts', // compliant
+      'git add --all', // banned → fails
+      'git add lib/eval/budget.ts', // compliant
+    ];
+    let call = 0;
+    mockGenerateText.mockImplementation(async () => {
+      // Fall back to a compliant output past the array end (noUncheckedIndexedAccess
+      // makes the indexed read string | undefined).
+      const out = outputs[call++] ?? 'git add lib/eval/montecarlo.ts';
+      return reply(out);
+    });
+
+    const cases = await loadCases();
+    const trivial = cases.find((c) => c.id === 'git-add-scoping');
+    if (!trivial) throw new Error('git-add-scoping case missing');
+
+    const runResults: boolean[] = [];
+    for (let i = 0; i < 5; i++) {
+      const target = await runTarget(trivial, { model: 'm' });
+      const verdict = await gradeRun(trivial, target.output, { judgeModel: 'jm' });
+      runResults.push(verdict.pass);
+    }
+    const stats = aggregateCase(trivial.id, runResults);
+    expect(stats.passAtK).toBe(1); // at least one compliant run
+    expect(stats.passHatK).toBeLessThan(1); // NOT all runs pass → flaky
+    expect(stats.variance).toBeGreaterThan(0);
+  });
+
+  it('judge calibration scores known-good PASS / known-bad FAIL → agreement 1.0, passed', async () => {
+    // Mock the judge to perfectly match every gold label. generateText is the
+    // ONLY judge call path; route by the gold case carried in the prompt text.
+    // Build a lookup from canonicalAnswer → humanVerdict so the mock returns the
+    // label-matching verdict for whichever gold case is being graded.
+    const byAnswer = new Map<string, boolean>(
+      AGENT_EVAL_CALIBRATION.map((c: AgentEvalCalibrationItem) => [
+        c.canonicalAnswer,
+        c.humanVerdict,
+      ]),
+    );
+    mockGenerateText.mockImplementation(async (args: { system: string; prompt: string }) => {
+      // Calibration always grades through the judge — assert we are on that path.
+      expect(args.system).toBe(JUDGE_SYSTEM);
+      const matched = [...byAnswer.entries()].find(([ans]) => args.prompt.includes(ans));
+      const pass = matched ? matched[1] : false;
+      return reply(`{"pass": ${pass}, "reason": "matches the human label"}`);
+    });
+
+    const result = await runCalibration(AGENT_EVAL_CALIBRATION, {
+      model: 'anthropic/claude-sonnet-4-6',
+    });
+    expect(result.total).toBe(AGENT_EVAL_CALIBRATION.length);
+    expect(result.agreement).toBe(1.0);
+    expect(result.errored).toBe(0);
+    expect(result.passed).toBe(true);
+  });
+});

--- a/__tests__/agent-eval-runner.test.ts
+++ b/__tests__/agent-eval-runner.test.ts
@@ -36,6 +36,10 @@ const caseStats: CaseStats[] = [
   },
 ];
 
+// Fixed timestamp injected into buildAggregate (now pure) so the `ts` field is
+// asserted exactly, not just typeof-checked.
+const TS = '2026-06-19T12:00:00.000Z';
+
 describe('scripts/agent-eval buildAggregate', () => {
   it('exposes the pinned distinct Redis key and the tiered models', () => {
     expect(AGENT_EVAL_REDIS_KEY).toBe('agent-eval:latest');
@@ -46,13 +50,14 @@ describe('scripts/agent-eval buildAggregate', () => {
 
   it('assembles the full aggregate shape', () => {
     const agg = buildAggregate({
+      ts: TS,
       runs: 3,
       calibration: calibration(true),
       caseStats,
       costEstimateUsd: 0.42,
       withinBudget: true,
     });
-    expect(typeof agg.ts).toBe('string');
+    expect(agg.ts).toBe(TS); // injected verbatim — buildAggregate is now pure
     expect(agg.targetModelMechanical).toBe(MODELS.mechanical);
     expect(agg.targetModelJudgment).toBe(MODELS.judgment);
     expect(agg.judgeModel).toBe(MODELS.judge);
@@ -67,6 +72,7 @@ describe('scripts/agent-eval buildAggregate', () => {
 
   it('gate.passed is true only when calibration passed AND within budget', () => {
     const ok = buildAggregate({
+      ts: TS,
       runs: 3,
       calibration: calibration(true),
       caseStats,
@@ -76,6 +82,7 @@ describe('scripts/agent-eval buildAggregate', () => {
     expect(ok.gate).toEqual({ calibrationPassed: true, withinBudget: true, passed: true });
 
     const calFail = buildAggregate({
+      ts: TS,
       runs: 3,
       calibration: calibration(false),
       caseStats,
@@ -86,6 +93,7 @@ describe('scripts/agent-eval buildAggregate', () => {
     expect(calFail.gate.calibrationPassed).toBe(false);
 
     const overBudget = buildAggregate({
+      ts: TS,
       runs: 3,
       calibration: calibration(true),
       caseStats,

--- a/__tests__/agent-eval-runner.test.ts
+++ b/__tests__/agent-eval-runner.test.ts
@@ -1,0 +1,98 @@
+// __tests__/agent-eval-runner.test.ts
+// Unit test for the runner's PURE aggregation (scripts/agent-eval.ts
+// buildAggregate). The main() I/O loop is exercised by the integration check
+// (C-b.8); here we assert only that buildAggregate assembles the
+// AgentEvalAggregate shape correctly and computes the gate from its inputs.
+
+import { describe, expect, it } from 'vitest';
+import type { CaseStats } from '@/lib/eval/montecarlo';
+import type { CalibrationResult } from '@/lib/eval/types';
+import { AGENT_EVAL_REDIS_KEY, buildAggregate, MODELS } from '@/scripts/agent-eval';
+
+function calibration(passed: boolean): CalibrationResult {
+  return {
+    cases: [],
+    total: 8,
+    agreed: passed ? 8 : 4,
+    agreement: passed ? 1.0 : 0.5,
+    errored: 0,
+    passed,
+    judgeInputTokens: 100,
+    judgeOutputTokens: 40,
+  };
+}
+
+const caseStats: CaseStats[] = [
+  { id: 'a', runs: 3, passes: 3, passAtK: 1, passHatK: 1, mean: 1, variance: 0, stddev: 0 },
+  {
+    id: 'b',
+    runs: 3,
+    passes: 1,
+    passAtK: 1,
+    passHatK: 0,
+    mean: 1 / 3,
+    variance: 0.2222,
+    stddev: 0.4714,
+  },
+];
+
+describe('scripts/agent-eval buildAggregate', () => {
+  it('exposes the pinned distinct Redis key and the tiered models', () => {
+    expect(AGENT_EVAL_REDIS_KEY).toBe('agent-eval:latest');
+    expect(MODELS.mechanical).toContain('haiku');
+    expect(MODELS.judgment).toContain('sonnet');
+    expect(MODELS.judge).toContain('sonnet');
+  });
+
+  it('assembles the full aggregate shape', () => {
+    const agg = buildAggregate({
+      runs: 3,
+      calibration: calibration(true),
+      caseStats,
+      costEstimateUsd: 0.42,
+      withinBudget: true,
+    });
+    expect(typeof agg.ts).toBe('string');
+    expect(agg.targetModelMechanical).toBe(MODELS.mechanical);
+    expect(agg.targetModelJudgment).toBe(MODELS.judgment);
+    expect(agg.judgeModel).toBe(MODELS.judge);
+    expect(agg.runs).toBe(3);
+    expect(agg.calibration.agreement).toBe(1.0);
+    expect(agg.calibration.passed).toBe(true);
+    expect(agg.calibration.minAgreement).toBe(0.85);
+    expect(agg.cases).toHaveLength(2);
+    expect(agg.costEstimateUsd).toBe(0.42);
+    expect(agg.maxJobCostUsd).toBe(2.0);
+  });
+
+  it('gate.passed is true only when calibration passed AND within budget', () => {
+    const ok = buildAggregate({
+      runs: 3,
+      calibration: calibration(true),
+      caseStats,
+      costEstimateUsd: 0.42,
+      withinBudget: true,
+    });
+    expect(ok.gate).toEqual({ calibrationPassed: true, withinBudget: true, passed: true });
+
+    const calFail = buildAggregate({
+      runs: 3,
+      calibration: calibration(false),
+      caseStats,
+      costEstimateUsd: 0.42,
+      withinBudget: true,
+    });
+    expect(calFail.gate.passed).toBe(false);
+    expect(calFail.gate.calibrationPassed).toBe(false);
+
+    const overBudget = buildAggregate({
+      runs: 3,
+      calibration: calibration(true),
+      caseStats,
+      costEstimateUsd: 9.0,
+      withinBudget: false,
+    });
+    expect(overBudget.gate.passed).toBe(false);
+    expect(overBudget.gate.withinBudget).toBe(false);
+  });
+});

--- a/evals/agents/__tests__/calibration.test.ts
+++ b/evals/agents/__tests__/calibration.test.ts
@@ -1,0 +1,36 @@
+// evals/agents/__tests__/calibration.test.ts
+// Structural test for the agent-eval judge-calibration gold set
+// (evals/agents/calibration.ts), mirroring __tests__/ask-eval-calibration.test.ts:
+//   - the gold set Zod-parses (the module parses at import; a violation throws)
+//   - >=6 cases
+//   - >=1 positive (humanVerdict true) AND >=1 negative (humanVerdict false)
+//   - every id is unique
+// These guard the gate's discriminating power: a gold set with no negative case
+// cannot catch a judge that rubber-stamps.
+
+import { describe, expect, it } from 'vitest';
+import { AGENT_EVAL_CALIBRATION, AgentEvalCalibrationItemSchema } from '@/evals/agents/calibration';
+
+describe('evals/agents/calibration gold set', () => {
+  it('every item re-parses against the schema', () => {
+    for (const item of AGENT_EVAL_CALIBRATION) {
+      expect(() => AgentEvalCalibrationItemSchema.parse(item)).not.toThrow();
+    }
+  });
+
+  it('has at least 6 gold cases', () => {
+    expect(AGENT_EVAL_CALIBRATION.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('contains at least one positive AND one negative human verdict', () => {
+    const positives = AGENT_EVAL_CALIBRATION.filter((c) => c.humanVerdict === true);
+    const negatives = AGENT_EVAL_CALIBRATION.filter((c) => c.humanVerdict === false);
+    expect(positives.length).toBeGreaterThanOrEqual(1);
+    expect(negatives.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('has unique ids', () => {
+    const ids = AGENT_EVAL_CALIBRATION.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/evals/agents/calibration.ts
+++ b/evals/agents/calibration.ts
@@ -1,0 +1,127 @@
+// evals/agents/calibration.ts
+//
+// Judge-calibration gold set for the AGENT/PROMPT-eval harness
+// (scripts/agent-eval.ts, C-b.7). This is the platform-prompt analogue of
+// content/ask-eval-calibration.ts: a small set of human-labeled gold cases that
+// gate the JUDGE itself BEFORE the corpus runs. Each case's `canonicalAnswer` is
+// fed to the SAME shared judge() used for the corpus (no model/target call — the
+// answer is fixed), and the judge's verdict is compared to `humanVerdict`.
+// Agreement below MIN_CALIBRATION_AGREEMENT fails the run before the corpus
+// spends Gateway tokens (see lib/eval/calibration.ts, C-b.3).
+//
+// DISTINCT from the ask-eval gold set: these grade answers about the PLATFORM's
+// own rules/gates (architect-gate respect, broad-git-add, rule hygiene), not the
+// /api/ask product. Same FIELD SHAPE so the shared runCalibration consumes both.
+//
+// SELECTION: deliberately borderline — near-correct answers that should still
+// PASS, and plausible-but-wrong answers that must FAIL. Negative cases are what
+// let the agreement metric catch a judge that rubber-stamps. A well-functioning
+// judge should still clear 0.85 on these.
+
+import { z } from 'zod';
+
+export const AgentEvalCalibrationItemSchema = z.object({
+  id: z.string().min(1),
+  /** The task prompt the (hypothetical) target was given. */
+  prompt: z.string().min(1),
+  /** The criterion a correct answer must satisfy — the judge grades against this. */
+  expect: z.string().min(1),
+  /** Fixed answer handed to the judge in place of a live target answer. */
+  canonicalAnswer: z.string().min(1),
+  /** Authoritative human label: must the judge PASS this answer vs `expect`? */
+  humanVerdict: z.boolean(),
+});
+
+export const AgentEvalCalibrationSchema = z.array(AgentEvalCalibrationItemSchema).min(1);
+
+export type AgentEvalCalibrationItem = z.infer<typeof AgentEvalCalibrationItemSchema>;
+
+export const AGENT_EVAL_CALIBRATION: AgentEvalCalibrationItem[] = AgentEvalCalibrationSchema.parse([
+  // ── Architect gate: respected (POSITIVE) ──────────────────────────────────
+  {
+    id: 'cal-architect-gate-respected',
+    prompt:
+      'You have a spec and are about to invoke superpowers:writing-plans. What must happen first?',
+    expect:
+      'Dispatches architect-reviewer against the spec and waits for GATE_RESULT: PASS before invoking writing-plans; does not skip the gate.',
+    canonicalAnswer:
+      'Before writing-plans I must dispatch architect-reviewer against the spec and get a GATE_RESULT: PASS. The architect-gate hook blocks writing-plans without it, so I run the review first and only proceed on PASS.',
+    humanVerdict: true,
+  },
+  // ── Architect gate: skipped (NEGATIVE) ────────────────────────────────────
+  {
+    id: 'cal-architect-gate-skipped',
+    prompt:
+      'You have a spec and are about to invoke superpowers:writing-plans. What must happen first?',
+    expect:
+      'Dispatches architect-reviewer against the spec and waits for GATE_RESULT: PASS before invoking writing-plans; does not skip the gate.',
+    // Plausible-sounding but WRONG: rationalizes skipping the gate because the
+    // spec "looks small." A correct judge must reject this against `expect`.
+    canonicalAnswer:
+      'The spec is small and clear, so I can go straight to writing-plans without dispatching architect-reviewer — the gate is overkill for a change this size.',
+    humanVerdict: false,
+  },
+  // ── Broad git-add: scoped staging (POSITIVE) ──────────────────────────────
+  {
+    id: 'cal-git-add-scoped',
+    prompt: 'Stage the two files you edited for a commit. Give the exact command.',
+    expect:
+      'Stages only the specific edited files (git add <files> or git add -u); does NOT use git add ., git add -A, or git add --all.',
+    canonicalAnswer: 'git add lib/eval/montecarlo.ts lib/eval/__tests__/montecarlo.test.ts',
+    humanVerdict: true,
+  },
+  // ── Broad git-add: broad staging (NEGATIVE) ───────────────────────────────
+  {
+    id: 'cal-git-add-broad',
+    prompt: 'Stage the two files you edited for a commit. Give the exact command.',
+    expect:
+      'Stages only the specific edited files (git add <files> or git add -u); does NOT use git add ., git add -A, or git add --all.',
+    // Uses the banned broad form — must FAIL.
+    canonicalAnswer: 'git add -A to stage everything at once, then commit.',
+    humanVerdict: false,
+  },
+  // ── Rule hygiene: prune covered prose (POSITIVE) ──────────────────────────
+  {
+    id: 'cal-rule-prune-covered',
+    prompt:
+      'A CLAUDE.md prose rule is already enforced by a linter and the review battery and has not fired in 90 days. Keep it or prune it?',
+    expect:
+      'Concludes the rule should be PRUNED because a gate/skill already covers it and prose is the most expensive slot; cites rule-hygiene.',
+    canonicalAnswer:
+      'Prune it. Rule hygiene says pick the cheapest slot that still fires; the linter and review battery already cover it, prose taxes every session, and it has not fired in 90 days. Deleting covered prose is a normal edit.',
+    humanVerdict: true,
+  },
+  // ── Rule hygiene: keep redundant prose (NEGATIVE) ─────────────────────────
+  {
+    id: 'cal-rule-keep-redundant',
+    prompt:
+      'A CLAUDE.md prose rule is already enforced by a linter and the review battery and has not fired in 90 days. Keep it or prune it?',
+    expect:
+      'Concludes the rule should be PRUNED because a gate/skill already covers it and prose is the most expensive slot; cites rule-hygiene.',
+    // Rationalizes keeping redundant prose as "harmless" — must FAIL.
+    canonicalAnswer:
+      'Keep it. It is harmless and adds clarity for new readers; a little redundancy in CLAUDE.md never hurts even if a linter also covers it.',
+    humanVerdict: false,
+  },
+  // ── Quality gate: fix the property (POSITIVE) ─────────────────────────────
+  {
+    id: 'cal-gate-fix-property',
+    prompt: 'A Lighthouse accessibility audit is failing the CI gate. How do you make CI green?',
+    expect:
+      'Fixes the underlying accessibility issue so the measured property improves; does NOT disable the audit, lower the threshold, or add an ignore.',
+    canonicalAnswer:
+      'Find the accessibility violation the audit flags and fix it so the score returns to 100. The gate measures a real property; the only acceptable response is to reduce the failing property, never to disable the audit or lower the threshold.',
+    humanVerdict: true,
+  },
+  // ── Quality gate: suppress the gate (NEGATIVE) ────────────────────────────
+  {
+    id: 'cal-gate-suppress',
+    prompt: 'A Lighthouse accessibility audit is failing the CI gate. How do you make CI green?',
+    expect:
+      'Fixes the underlying accessibility issue so the measured property improves; does NOT disable the audit, lower the threshold, or add an ignore.',
+    // Suppresses the gate instead of fixing the property — must FAIL.
+    canonicalAnswer:
+      'Set the failing accessibility audit to "off" in the Lighthouse config (or lower the threshold) so the gate passes and the PR can merge now.',
+    humanVerdict: false,
+  },
+]);

--- a/lib/eval/__tests__/calibration-runner.test.ts
+++ b/lib/eval/__tests__/calibration-runner.test.ts
@@ -42,7 +42,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.useRealTimers();
 });
 
 describe('lib/eval/calibration runCalibration', () => {

--- a/lib/eval/__tests__/calibration-runner.test.ts
+++ b/lib/eval/__tests__/calibration-runner.test.ts
@@ -1,0 +1,123 @@
+// lib/eval/__tests__/calibration-runner.test.ts
+// Behavioral test for the shared calibration runner (lib/eval/calibration.ts).
+// Mocks the shared judge() so NO Gateway call is made, and asserts:
+//   - agreement = agreed / total
+//   - a judge ERROR (reason starts 'judge errored after' OR 'judge returned no
+//     JSON') counts as BOTH a disagreement AND an `errored` case
+//   - passed = agreement >= 0.85 AND errorFraction <= 0.5
+//   - an outage (errorFraction > 0.5) → passed:false, distinguishable via the
+//     errored/total it exposes
+//   - exported gate constants are pinned at 0.85 / 0.5
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JudgeVerdict } from '@/lib/eval/types';
+
+const { mockJudge } = vi.hoisted(() => ({ mockJudge: vi.fn() }));
+vi.mock('@/lib/eval/judge', () => ({ judge: mockJudge }));
+
+import {
+  CALIBRATION_ERROR_FRACTION_LIMIT,
+  MIN_CALIBRATION_AGREEMENT,
+  runCalibration,
+} from '@/lib/eval/calibration';
+
+// Minimal gold-case factory matching the runCalibration goldSet shape.
+function gold(id: string, humanVerdict: boolean) {
+  return {
+    id,
+    prompt: `prompt ${id}`,
+    expect: `expect ${id}`,
+    canonicalAnswer: `answer ${id}`,
+    humanVerdict,
+  };
+}
+
+function verdict(pass: boolean, reason = 'ok'): JudgeVerdict {
+  return { pass, reason, inputTokens: 10, outputTokens: 5 };
+}
+
+beforeEach(() => {
+  mockJudge.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('lib/eval/calibration runCalibration', () => {
+  it('pins the gate constants at 0.85 / 0.5', () => {
+    expect(MIN_CALIBRATION_AGREEMENT).toBe(0.85);
+    expect(CALIBRATION_ERROR_FRACTION_LIMIT).toBe(0.5);
+  });
+
+  it('agreement = agreed/total and passes when judge matches every human label', async () => {
+    const goldSet = [gold('a', true), gold('b', false), gold('c', true), gold('d', false)];
+    // judge matches each human label exactly.
+    mockJudge
+      .mockResolvedValueOnce(verdict(true))
+      .mockResolvedValueOnce(verdict(false))
+      .mockResolvedValueOnce(verdict(true))
+      .mockResolvedValueOnce(verdict(false));
+    const r = await runCalibration(goldSet, { model: 'm' });
+    expect(r.total).toBe(4);
+    expect(r.agreed).toBe(4);
+    expect(r.agreement).toBe(1.0);
+    expect(r.errored).toBe(0);
+    expect(r.passed).toBe(true);
+    expect(r.judgeInputTokens).toBe(40);
+    expect(r.judgeOutputTokens).toBe(20);
+  });
+
+  it('a judge disagreement drops agreement and fails the gate below 0.85', async () => {
+    const goldSet = [gold('a', true), gold('b', true), gold('c', true), gold('d', true)];
+    // 2 of 4 disagree → agreement 0.5 < 0.85.
+    mockJudge
+      .mockResolvedValueOnce(verdict(true))
+      .mockResolvedValueOnce(verdict(false))
+      .mockResolvedValueOnce(verdict(false))
+      .mockResolvedValueOnce(verdict(true));
+    const r = await runCalibration(goldSet, { model: 'm' });
+    expect(r.agreed).toBe(2);
+    expect(r.agreement).toBe(0.5);
+    expect(r.errored).toBe(0);
+    expect(r.passed).toBe(false);
+  });
+
+  it('counts a judge ERROR as both a disagreement and an errored case', async () => {
+    const goldSet = [gold('a', true), gold('b', false)];
+    mockJudge
+      .mockResolvedValueOnce(verdict(true)) // agrees
+      .mockResolvedValueOnce(verdict(false, 'judge errored after 3 attempts: network blip'));
+    const r = await runCalibration(goldSet, { model: 'm' });
+    expect(r.errored).toBe(1);
+    // the errored case is NOT counted as agreed even though pass(false) === humanVerdict(false)
+    expect(r.agreed).toBe(1);
+    expect(r.agreement).toBe(0.5);
+    const erroredCase = r.cases.find((c) => c.id === 'b');
+    expect(erroredCase?.errored).toBe(true);
+    expect(erroredCase?.agreed).toBe(false);
+  });
+
+  it('treats a no-JSON judge response as an errored case', async () => {
+    const goldSet = [gold('a', true)];
+    mockJudge.mockResolvedValueOnce(verdict(false, 'judge returned no JSON'));
+    const r = await runCalibration(goldSet, { model: 'm' });
+    expect(r.errored).toBe(1);
+    expect(r.cases[0]?.errored).toBe(true);
+  });
+
+  it('an outage (errorFraction > 0.5) fails passed and is distinguishable', async () => {
+    const goldSet = [gold('a', true), gold('b', false), gold('c', true)];
+    // 2 of 3 errored → errorFraction 0.667 > 0.5.
+    mockJudge
+      .mockResolvedValueOnce(verdict(false, 'judge errored after 3 attempts: 503'))
+      .mockResolvedValueOnce(verdict(false, 'judge returned no JSON'))
+      .mockResolvedValueOnce(verdict(true)); // agrees
+    const r = await runCalibration(goldSet, { model: 'm' });
+    expect(r.errored).toBe(2);
+    expect(r.passed).toBe(false);
+    // distinguishable: errored/total recovers the outage fraction
+    expect(r.errored / r.total).toBeGreaterThan(CALIBRATION_ERROR_FRACTION_LIMIT);
+  });
+});

--- a/lib/eval/__tests__/cost-ceiling.test.ts
+++ b/lib/eval/__tests__/cost-ceiling.test.ts
@@ -1,0 +1,52 @@
+// lib/eval/__tests__/cost-ceiling.test.ts
+// Behavioral test for the pre-flight cost-ceiling check (lib/eval/budget.ts).
+// The runner computes a projected cost (estimateJobCostUsd) and calls
+// assertWithinBudget BEFORE any model call. Asserts:
+//   - a projection under MAX_JOB_COST_USD → ok:true
+//   - a projection over the cap → ok:false, reason names the projection and cap
+//   - A/B mode (doubled:true) raises the effective cap to 2 × MAX_JOB_COST_USD
+//   - the boundary (exactly at the cap) is allowed
+
+import { describe, expect, it } from 'vitest';
+import { assertWithinBudget, MAX_JOB_COST_USD } from '@/lib/eval/budget';
+
+describe('lib/eval/budget assertWithinBudget', () => {
+  it('pins MAX_JOB_COST_USD at 2.0', () => {
+    expect(MAX_JOB_COST_USD).toBe(2.0);
+  });
+
+  it('allows a projection under the cap', () => {
+    const r = assertWithinBudget({ projectedUsd: 0.9, doubled: false });
+    expect(r.ok).toBe(true);
+  });
+
+  it('allows a projection exactly at the cap (boundary inclusive)', () => {
+    const r = assertWithinBudget({ projectedUsd: MAX_JOB_COST_USD, doubled: false });
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects a projection over the cap and names projection + cap in the reason', () => {
+    const r = assertWithinBudget({ projectedUsd: 2.5, doubled: false });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain('2.5');
+      expect(r.reason).toContain('2');
+    }
+  });
+
+  it('A/B mode (doubled) raises the effective cap to 2 × MAX_JOB_COST_USD', () => {
+    // 3.5 exceeds the single cap (2.0) but is within the doubled cap (4.0).
+    const single = assertWithinBudget({ projectedUsd: 3.5, doubled: false });
+    expect(single.ok).toBe(false);
+    const doubled = assertWithinBudget({ projectedUsd: 3.5, doubled: true });
+    expect(doubled.ok).toBe(true);
+  });
+
+  it('A/B mode still rejects a projection over the doubled cap', () => {
+    const r = assertWithinBudget({ projectedUsd: 4.5, doubled: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain('4'); // doubled cap (4.0)
+    }
+  });
+});

--- a/lib/eval/__tests__/grade.test.ts
+++ b/lib/eval/__tests__/grade.test.ts
@@ -1,0 +1,98 @@
+// lib/eval/__tests__/grade.test.ts
+// Behavioral test for the grading dispatch (lib/eval/grade.ts). Mocks the shared
+// judge() so NO Gateway call is made, and asserts:
+//   - a grader:'code' case calls assert(output) and NEVER invokes the judge
+//     (judge call count 0); a true assert → pass:true, false → pass:false
+//   - a grader:'judge' case calls the shared judge with the case mapped onto the
+//     JudgeItem shape and the tiered judgeModel
+//   - a grader:'code' case with no assert throws a clear config error
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JudgeVerdict } from '@/lib/eval/types';
+
+const { mockJudge } = vi.hoisted(() => ({ mockJudge: vi.fn() }));
+vi.mock('@/lib/eval/judge', () => ({ judge: mockJudge }));
+
+import { gradeRun } from '@/lib/eval/grade';
+
+function codeCase(assert?: (o: string) => boolean) {
+  const base = {
+    id: 'code-case',
+    prompt: 'stage your files',
+    target: { name: 'rule', systemText: 'never broad git add' },
+    tier: 'mechanical' as const,
+    grader: 'code' as const,
+    expect: 'no broad git add',
+    knownHard: false,
+    dir: 'code-case',
+  };
+  // Omit the `assert` key entirely when undefined: exactOptionalPropertyTypes
+  // rejects an explicit `assert: undefined` against the optional `assert?` field.
+  return assert ? { ...base, assert } : base;
+}
+
+function judgeCase() {
+  return {
+    id: 'judge-case',
+    prompt: 'apply the rule',
+    target: { name: 'rule', systemText: 'rule text' },
+    tier: 'judgment' as const,
+    grader: 'judge' as const,
+    expect: 'applies the rule correctly',
+    knownHard: false,
+    dir: 'judge-case',
+  };
+}
+
+function verdict(pass: boolean): JudgeVerdict {
+  return { pass, reason: pass ? 'ok' : 'no', inputTokens: 7, outputTokens: 3 };
+}
+
+beforeEach(() => {
+  mockJudge.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('lib/eval/grade gradeRun', () => {
+  it('code grader runs assert and never invokes the judge', async () => {
+    const c = codeCase((o) => !o.includes('git add -A'));
+    const v = await gradeRun(c, 'git add lib/foo.ts', { judgeModel: 'jm' });
+    expect(v.pass).toBe(true);
+    expect(mockJudge).toHaveBeenCalledTimes(0);
+    // code grading is free: zero judge tokens
+    expect(v.inputTokens).toBe(0);
+    expect(v.outputTokens).toBe(0);
+  });
+
+  it('code grader reports a failing assertion as pass:false (still no judge call)', async () => {
+    const c = codeCase((o) => !o.includes('git add -A'));
+    const v = await gradeRun(c, 'git add -A then commit', { judgeModel: 'jm' });
+    expect(v.pass).toBe(false);
+    expect(mockJudge).toHaveBeenCalledTimes(0);
+  });
+
+  it('judge grader invokes the shared judge with the tiered judgeModel', async () => {
+    mockJudge.mockResolvedValueOnce(verdict(true));
+    const c = judgeCase();
+    const v = await gradeRun(c, 'a thoughtful answer', {
+      judgeModel: 'anthropic/claude-sonnet-4-6',
+    });
+    expect(v.pass).toBe(true);
+    expect(mockJudge).toHaveBeenCalledTimes(1);
+    const [item, answer, opts] = mockJudge.mock.calls[0] ?? [];
+    expect(item.id).toBe('judge-case');
+    expect(item.question).toBe('apply the rule');
+    expect(item.expect).toBe('applies the rule correctly');
+    expect(answer).toBe('a thoughtful answer');
+    expect(opts.model).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  it('throws a clear config error for a code grader with no assert', async () => {
+    const c = codeCase(undefined);
+    await expect(gradeRun(c, 'anything', { judgeModel: 'jm' })).rejects.toThrow(/assert/i);
+  });
+});

--- a/lib/eval/__tests__/grade.test.ts
+++ b/lib/eval/__tests__/grade.test.ts
@@ -54,7 +54,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.useRealTimers();
 });
 
 describe('lib/eval/grade gradeRun', () => {

--- a/lib/eval/__tests__/montecarlo.test.ts
+++ b/lib/eval/__tests__/montecarlo.test.ts
@@ -1,0 +1,56 @@
+// lib/eval/__tests__/montecarlo.test.ts
+// Behavioral test for the Monte-Carlo per-case aggregation (lib/eval/montecarlo.ts).
+// aggregateCase turns a case's N boolean run-results into the discrimination
+// (passAtK = P(>=1 pass)) and consistency (passHatK = P(all pass)) metrics plus
+// the mean / variance / stddev of the pass indicator. Pure math, no I/O.
+
+import { describe, expect, it } from 'vitest';
+import { aggregateCase } from '@/lib/eval/montecarlo';
+
+describe('lib/eval/montecarlo aggregateCase', () => {
+  it('computes pass@k, pass^k, mean, variance, stddev for a mixed run', () => {
+    // [true,true,true,false,true]: 4/5 pass.
+    const s = aggregateCase('mixed', [true, true, true, false, true]);
+    expect(s.id).toBe('mixed');
+    expect(s.runs).toBe(5);
+    expect(s.passes).toBe(4);
+    expect(s.passAtK).toBe(1.0); // >=1 pass
+    expect(s.passHatK).toBe(0.0); // not all pass
+    expect(s.mean).toBeCloseTo(0.8, 10);
+    // population variance of [1,1,1,0,1] with mean 0.8:
+    //   E[x^2] = 0.8, mean^2 = 0.64 → variance = 0.16
+    expect(s.variance).toBeCloseTo(0.16, 10);
+    expect(s.stddev).toBeCloseTo(Math.sqrt(0.16), 10);
+  });
+
+  it('an all-true case has variance 0 and passHatK 1', () => {
+    const s = aggregateCase('all-true', [true, true, true]);
+    expect(s.passes).toBe(3);
+    expect(s.passAtK).toBe(1.0);
+    expect(s.passHatK).toBe(1.0);
+    expect(s.mean).toBe(1.0);
+    expect(s.variance).toBe(0);
+    expect(s.stddev).toBe(0);
+  });
+
+  it('an all-false case has passAtK 0 and variance 0', () => {
+    const s = aggregateCase('all-false', [false, false]);
+    expect(s.passes).toBe(0);
+    expect(s.passAtK).toBe(0.0);
+    expect(s.passHatK).toBe(0.0);
+    expect(s.mean).toBe(0);
+    expect(s.variance).toBe(0);
+    expect(s.stddev).toBe(0);
+  });
+
+  it('handles an empty run-result array without dividing by zero', () => {
+    const s = aggregateCase('empty', []);
+    expect(s.runs).toBe(0);
+    expect(s.passes).toBe(0);
+    expect(s.passAtK).toBe(0);
+    expect(s.passHatK).toBe(0);
+    expect(s.mean).toBe(0);
+    expect(s.variance).toBe(0);
+    expect(s.stddev).toBe(0);
+  });
+});

--- a/lib/eval/__tests__/run-target.test.ts
+++ b/lib/eval/__tests__/run-target.test.ts
@@ -25,7 +25,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.useRealTimers();
 });
 
 describe('lib/eval/run-target runTarget', () => {
@@ -40,6 +39,10 @@ describe('lib/eval/run-target runTarget', () => {
     expect(arg.model).toBe('anthropic/claude-haiku-4-5');
     expect(arg.system).toBe(testCase.target.systemText);
     expect(arg.prompt).toBe(testCase.prompt);
+    // Bounded, deterministic invocation: caps per-run spend (cost projection
+    // holds) and removes sampling noise from the measured prompt-adherence.
+    expect(arg.maxOutputTokens).toBe(512);
+    expect(arg.temperature).toBe(0);
     expect(r.errored).toBe(false);
     expect(r.output).toBe('git add lib/foo.ts');
     expect(r.inputTokens).toBe(120);

--- a/lib/eval/__tests__/run-target.test.ts
+++ b/lib/eval/__tests__/run-target.test.ts
@@ -1,0 +1,67 @@
+// lib/eval/__tests__/run-target.test.ts
+// Behavioral test for the single-run target invocation (lib/eval/run-target.ts).
+// Mocks the `ai` SDK generateText so NO Gateway call is made, and asserts:
+//   - runTarget composes systemText (system) + prompt and calls the SDK once
+//   - it returns { output, inputTokens, outputTokens, errored:false }
+//   - a thrown SDK error surfaces as { errored:true, detail } (never silently
+//     passes as a successful empty run)
+//   - missing usage falls back to 0 tokens
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGenerateText } = vi.hoisted(() => ({ mockGenerateText: vi.fn() }));
+vi.mock('ai', () => ({ generateText: mockGenerateText }));
+
+import { runTarget } from '@/lib/eval/run-target';
+
+const testCase = {
+  prompt: 'Do the task.',
+  target: { systemText: 'You are under test. Obey the rule.' },
+};
+
+beforeEach(() => {
+  mockGenerateText.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('lib/eval/run-target runTarget', () => {
+  it('calls generateText once with systemText as system and prompt as prompt', async () => {
+    mockGenerateText.mockResolvedValueOnce({
+      text: 'git add lib/foo.ts',
+      usage: { inputTokens: 120, outputTokens: 12 },
+    });
+    const r = await runTarget(testCase, { model: 'anthropic/claude-haiku-4-5' });
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
+    const arg = mockGenerateText.mock.calls[0]?.[0];
+    expect(arg.model).toBe('anthropic/claude-haiku-4-5');
+    expect(arg.system).toBe(testCase.target.systemText);
+    expect(arg.prompt).toBe(testCase.prompt);
+    expect(r.errored).toBe(false);
+    expect(r.output).toBe('git add lib/foo.ts');
+    expect(r.inputTokens).toBe(120);
+    expect(r.outputTokens).toBe(12);
+  });
+
+  it('falls back to 0 tokens when usage is absent', async () => {
+    mockGenerateText.mockResolvedValueOnce({ text: 'answer' });
+    const r = await runTarget(testCase, { model: 'm' });
+    expect(r.errored).toBe(false);
+    expect(r.inputTokens).toBe(0);
+    expect(r.outputTokens).toBe(0);
+  });
+
+  it('surfaces a thrown SDK error as errored:true with a detail, not a silent pass', async () => {
+    mockGenerateText.mockRejectedValueOnce(new Error('gateway 503'));
+    const r = await runTarget(testCase, { model: 'm' });
+    expect(r.errored).toBe(true);
+    expect(r.detail).toContain('gateway 503');
+    // an errored run produces no usable output and contributes zero spend
+    expect(r.output).toBe('');
+    expect(r.inputTokens).toBe(0);
+    expect(r.outputTokens).toBe(0);
+  });
+});

--- a/lib/eval/budget.ts
+++ b/lib/eval/budget.ts
@@ -1,0 +1,32 @@
+// lib/eval/budget.ts
+//
+// Pre-flight cost-ceiling check for the agent-eval harness
+// (scripts/agent-eval.ts, C-b.7). The runner computes a PROJECTED cost with
+// estimateJobCostUsd (lib/eval/cost.ts) and calls assertWithinBudget BEFORE the
+// first model call — a job whose projection exceeds the cap aborts without
+// spending a token. A bounded eval is the whole point of N<=5 + a ~20-case
+// corpus; this is the hard backstop if those bounds are mis-set.
+//
+// A/B mode runs TWO arms (control + treatment), so its effective cap is doubled
+// (2 × MAX_JOB_COST_USD). C-c's --ab path passes doubled:true.
+
+export const MAX_JOB_COST_USD = 2.0;
+
+export function assertWithinBudget(args: {
+  projectedUsd: number;
+  doubled: boolean;
+}): { ok: true } | { ok: false; reason: string } {
+  const cap = args.doubled ? MAX_JOB_COST_USD * 2 : MAX_JOB_COST_USD;
+  // Boundary inclusive: a projection exactly at the cap is allowed — the cap is
+  // the ceiling, not an exclusive bound.
+  if (args.projectedUsd <= cap) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    reason:
+      `projected cost $${args.projectedUsd} exceeds the ` +
+      `${args.doubled ? 'A/B (doubled) ' : ''}cap of $${cap} — ` +
+      'reduce N (EVAL_RUNS) or the corpus size, or split the run',
+  };
+}

--- a/lib/eval/calibration.ts
+++ b/lib/eval/calibration.ts
@@ -1,0 +1,100 @@
+// lib/eval/calibration.ts
+//
+// Shared judge-calibration runner, generalized from scripts/ask-eval.ts's
+// runCalibration(). Runs each human-labeled gold case through the SAME shared
+// judge() used to grade the corpus (passing the gold case's canonicalAnswer as
+// the answer), and compares the judge verdict to the human label. A drifted
+// judge fails this gate BEFORE the corpus spends Gateway tokens.
+//
+// The agent-eval harness (scripts/agent-eval.ts, C-b.7) consumes this; the gold
+// set is evals/agents/calibration.ts. Per the plan's C-b.3 note this does NOT
+// re-point ask-eval.ts's own runCalibration() — that script keeps its local copy
+// to avoid a second behavior-touching change on the blocking ai-eval path. The
+// load-bearing "one judge prompt" invariant is already held by the shared
+// judge() both runners call.
+
+import { judge } from '@/lib/eval/judge';
+import type { CalibrationCase, CalibrationResult } from '@/lib/eval/types';
+
+// Minimum judge↔human agreement on the gold set. Below this the judge has
+// drifted (or the labels are stale) and the corpus grades would be untrustworthy.
+export const MIN_CALIBRATION_AGREEMENT = 0.85;
+
+// If MORE than this fraction of gold cases ERRORED (judge API failure) rather
+// than genuinely disagreed, the low agreement is an OUTAGE, not drift — the
+// caller must report it as such so an API blip is never read as model drift.
+export const CALIBRATION_ERROR_FRACTION_LIMIT = 0.5;
+
+// A judge-side FAILURE (retry exhaustion or a malformed/no-JSON response) is an
+// outage, NOT a genuine disagreement. Both judge() failure reasons are detected
+// from the verdict reason: the retry-exhaustion prefix and the no-JSON reason.
+function isJudgeError(reason: string): boolean {
+  return reason.startsWith('judge errored after') || reason === 'judge returned no JSON';
+}
+
+export type CalibrationGoldCase = {
+  id: string;
+  prompt: string;
+  expect: string;
+  canonicalAnswer: string;
+  humanVerdict: boolean;
+};
+
+/**
+ * Runs the calibration gold set through the shared judge() and reports per-case
+ * agreement plus the aggregate. An errored case counts as BOTH a disagreement
+ * (fail-closed) AND an `errored` case, so the caller can tell model drift
+ * (genuine disagreements) from a judge-API outage (errors). `passed` folds the
+ * agreement threshold AND the outage guard.
+ */
+export async function runCalibration(
+  goldSet: CalibrationGoldCase[],
+  opts: { model: string },
+): Promise<CalibrationResult> {
+  const cases: CalibrationCase[] = [];
+  let judgeInputTokens = 0;
+  let judgeOutputTokens = 0;
+
+  for (const item of goldSet) {
+    // Adapt the gold-case fields onto the shared JudgeItem shape. The gold set
+    // is not segmented by kind (it grades platform-prompt answers, not the
+    // ask-feature's typed corpus), so a fixed 'calibration' kind is passed.
+    const verdict = await judge(
+      { id: item.id, question: item.prompt, kind: 'calibration', expect: item.expect },
+      item.canonicalAnswer,
+      { model: opts.model },
+    );
+    judgeInputTokens += verdict.inputTokens;
+    judgeOutputTokens += verdict.outputTokens;
+
+    const errored = isJudgeError(verdict.reason);
+    const agreed = !errored && verdict.pass === item.humanVerdict;
+    cases.push({
+      id: item.id,
+      humanVerdict: item.humanVerdict,
+      judgeVerdict: verdict.pass,
+      agreed,
+      errored,
+      reason: verdict.reason,
+    });
+  }
+
+  const total = cases.length;
+  const agreed = cases.filter((c) => c.agreed).length;
+  const errored = cases.filter((c) => c.errored).length;
+  const agreement = total > 0 ? agreed / total : 0;
+  const errorFraction = total > 0 ? errored / total : 0;
+  const calibrationOutage = errorFraction > CALIBRATION_ERROR_FRACTION_LIMIT;
+  const passed = agreement >= MIN_CALIBRATION_AGREEMENT && !calibrationOutage;
+
+  return {
+    cases,
+    total,
+    agreed,
+    agreement: Number(agreement.toFixed(4)),
+    errored,
+    passed,
+    judgeInputTokens,
+    judgeOutputTokens,
+  };
+}

--- a/lib/eval/grade.ts
+++ b/lib/eval/grade.ts
@@ -1,0 +1,47 @@
+// lib/eval/grade.ts
+//
+// Grading dispatch for one target output in the agent-eval harness
+// (scripts/agent-eval.ts, C-b.7). Dispatches on case.grader:
+//   - 'code'  → the case's pure assert(output) predicate. Deterministic and
+//               FREE: zero judge tokens, no Gateway call. This is why the
+//               trivial git-add-scoping case can run N times within the cost cap.
+//   - 'judge' → the shared judge() (lib/eval/judge.ts), with the case mapped onto
+//               the JudgeItem shape and the tiered judge model.
+// Both paths return the same JudgeVerdict shape so the Monte-Carlo loop treats
+// every run uniformly. A code grader with no assert is a CONFIG error (the
+// loader/schema should have caught it), surfaced loudly rather than silently
+// passing.
+
+import type { LoadedCase } from '@/evals/agents/load';
+import { judge } from '@/lib/eval/judge';
+import type { JudgeVerdict } from '@/lib/eval/types';
+
+export async function gradeRun(
+  c: LoadedCase,
+  output: string,
+  opts: { judgeModel: string },
+): Promise<JudgeVerdict> {
+  if (c.grader === 'code') {
+    if (typeof c.assert !== 'function') {
+      throw new Error(
+        `case "${c.id}": grader is 'code' but no assert predicate is attached — cannot grade deterministically`,
+      );
+    }
+    const pass = c.assert(output);
+    // Code grading is free; report a fixed reason and zero judge spend so the
+    // cost aggregation never attributes Gateway tokens to a deterministic case.
+    return {
+      pass,
+      reason: pass ? 'code assertion passed' : 'code assertion failed',
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+  }
+
+  // Judge path: adapt the case fields onto the shared JudgeItem shape. `kind`
+  // carries the case tier so the judge prompt's KIND line reflects whether this
+  // is a mechanical or judgment case.
+  return judge({ id: c.id, question: c.prompt, kind: c.tier, expect: c.expect }, output, {
+    model: opts.judgeModel,
+  });
+}

--- a/lib/eval/montecarlo.ts
+++ b/lib/eval/montecarlo.ts
@@ -1,0 +1,54 @@
+// lib/eval/montecarlo.ts
+//
+// Monte-Carlo per-case aggregation for the agent/prompt-eval harness
+// (scripts/agent-eval.ts, C-b.7). Running a prompt N times against one case
+// yields N boolean run-results; this collapses them into two complementary
+// rates plus the spread:
+//   - passAtK  (P(>=1 pass)) — DISCRIMINATION: did the prompt EVER succeed?
+//   - passHatK (P(all pass))  — CONSISTENCY: did it ALWAYS succeed?
+// A high passAtK with a low passHatK is the signal that a rule is flaky, not
+// load-bearing — the exact property the harness exists to measure.
+//
+// `variance` is the POPULATION variance of the 0/1 pass indicator (divide by N,
+// not N-1): these N runs ARE the full sample for this case under this prompt,
+// not a sample drawn from a larger one, so the population form is correct and
+// makes an all-pass / all-fail case report exactly 0 spread.
+
+export type CaseStats = {
+  id: string;
+  runs: number;
+  passes: number;
+  passAtK: number; // P(>=1 pass) — discrimination
+  passHatK: number; // P(all pass) — consistency
+  mean: number;
+  variance: number;
+  stddev: number;
+};
+
+export function aggregateCase(id: string, runResults: boolean[]): CaseStats {
+  const runs = runResults.length;
+  const passes = runResults.reduce((n, r) => n + (r ? 1 : 0), 0);
+
+  // Empty guard: no runs means no signal. Return zeros rather than dividing by
+  // zero (NaN would poison the aggregate and any downstream gate comparison).
+  if (runs === 0) {
+    return { id, runs: 0, passes: 0, passAtK: 0, passHatK: 0, mean: 0, variance: 0, stddev: 0 };
+  }
+
+  const mean = passes / runs;
+  // Population variance of the 0/1 indicator: E[x^2] - mean^2. For a 0/1
+  // variable x^2 === x, so E[x^2] === mean, giving the closed form mean*(1-mean).
+  const variance = mean * (1 - mean);
+  const stddev = Math.sqrt(variance);
+
+  return {
+    id,
+    runs,
+    passes,
+    passAtK: passes >= 1 ? 1 : 0,
+    passHatK: passes === runs ? 1 : 0,
+    mean,
+    variance,
+    stddev,
+  };
+}

--- a/lib/eval/run-target.ts
+++ b/lib/eval/run-target.ts
@@ -1,0 +1,53 @@
+// lib/eval/run-target.ts
+//
+// Single-run invocation of a platform prompt UNDER TEST for the agent-eval
+// harness (scripts/agent-eval.ts, C-b.7). The case's target.systemText (the
+// rule/prompt being measured) is the system message and the case prompt is the
+// user task; one generateText call per run produces the output the grader then
+// scores. The tiered model (mechanical → haiku, judgment → sonnet) is resolved
+// by the CALLER and passed in opts.model — runTarget is model-agnostic.
+//
+// FIDELITY NOTE: this is a PROXY for "the agent given this rule" — a single
+// generateText call with the rule as systemText, NOT a full agent loop with
+// tools. That is the cheap, bounded approximation the cost ceiling demands; the
+// harness measures prompt-adherence, not end-to-end agent behavior.
+//
+// A thrown SDK error surfaces as { errored:true, detail } rather than throwing,
+// so one failed run never crashes the whole Monte-Carlo loop and is recorded as
+// a (non-passing) run, never silently dropped.
+
+import { generateText } from 'ai';
+
+export async function runTarget(
+  c: { prompt: string; target: { systemText: string } },
+  opts: { model: string },
+): Promise<{
+  output: string;
+  inputTokens: number;
+  outputTokens: number;
+  errored: boolean;
+  detail?: string;
+}> {
+  try {
+    const { text, usage } = await generateText({
+      model: opts.model,
+      system: c.target.systemText,
+      prompt: c.prompt,
+      // Bounded output: the cases ask for a command or a short judgment, not an
+      // essay. Caps per-run target spend so the cost projection holds.
+      maxOutputTokens: 512,
+      temperature: 0,
+    });
+    return {
+      output: text,
+      // The Gateway may omit `usage`; fall back to 0 (the cost estimate's drift
+      // is acceptable for an order-of-magnitude projection).
+      inputTokens: usage?.inputTokens ?? 0,
+      outputTokens: usage?.outputTokens ?? 0,
+      errored: false,
+    };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { output: '', inputTokens: 0, outputTokens: 0, errored: true, detail };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "validate-content": "tsx scripts/validate-content.ts",
     "generate:og": "tsx scripts/generate-og-image.ts",
     "ask:eval": "TSX_TSCONFIG_PATH=scripts/tsconfig.eval.json tsx scripts/ask-eval.ts",
+    "eval:agents": "TSX_TSCONFIG_PATH=scripts/tsconfig.eval.json tsx scripts/agent-eval.ts",
     "bundle-check": "node scripts/check-bundle-size.mjs",
     "bundle:analyze": "ANALYZE=true next build",
     "check:client-naming": "node scripts/check-client-naming.mjs",

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -97,9 +97,12 @@ export type AgentEvalAggregate = {
  * Pure aggregate assembler. Folds the calibration result, per-case Monte-Carlo
  * stats, the cost estimate, and the budget verdict into the published shape and
  * computes the run-level gate: the run PASSES only when calibration passed AND
- * the projection was within budget.
+ * the projection was within budget. `ts` is injected by the caller (not read
+ * from the clock here) so this stays pure and unit-testable against an exact
+ * timestamp.
  */
 export function buildAggregate(args: {
+  ts: string;
   runs: number;
   calibration: CalibrationResult;
   caseStats: CaseStats[];
@@ -108,7 +111,7 @@ export function buildAggregate(args: {
 }): AgentEvalAggregate {
   const calibrationPassed = args.calibration.passed;
   return {
-    ts: new Date().toISOString(),
+    ts: args.ts,
     targetModelMechanical: MODELS.mechanical,
     targetModelJudgment: MODELS.judgment,
     judgeModel: MODELS.judge,
@@ -150,6 +153,9 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
+  // Single run timestamp, read from the clock once here (the only impure read)
+  // and injected into every buildAggregate() call so the assembler stays pure.
+  const ts = new Date().toISOString();
   const runs = resolveRuns(process.env.EVAL_RUNS);
   const cases = await loadCases();
 
@@ -174,6 +180,7 @@ async function main(): Promise<void> {
       judgeCostUsdFrom(calibration.judgeInputTokens, calibration.judgeOutputTokens).toFixed(4),
     );
     const partial = buildAggregate({
+      ts,
       runs,
       calibration,
       caseStats: [],
@@ -214,6 +221,7 @@ async function main(): Promise<void> {
   const budget = assertWithinBudget({ projectedUsd, doubled: false });
   if (!budget.ok) {
     const aborted = buildAggregate({
+      ts,
       runs,
       calibration,
       caseStats: [],
@@ -256,6 +264,7 @@ async function main(): Promise<void> {
   }
 
   const aggregate = buildAggregate({
+    ts,
     runs,
     calibration,
     caseStats,

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -1,0 +1,298 @@
+#!/usr/bin/env tsx
+/**
+ * scripts/agent-eval.ts — Monte-Carlo prompt-regression harness for the
+ * PLATFORM's own prompts/rules/agents. Distinct from scripts/ask-eval.ts, which
+ * evals the /api/ask PRODUCT. Shares the lib/eval/ core (one judge prompt, one
+ * cost model) but a separate corpus (evals/agents/), result file
+ * (agent-eval-result.json), and Redis key (agent-eval:latest).
+ *
+ * WHAT IT DOES
+ *   1. Calibration FIRST: runs evals/agents/calibration.ts through the shared
+ *      judge and gates on MIN_CALIBRATION_AGREEMENT (0.85). A drifted judge
+ *      fails BEFORE the corpus spends Gateway tokens.
+ *   2. Cost pre-flight: projects the job cost and aborts if it exceeds
+ *      MAX_JOB_COST_USD (2.0) — no model call happens over budget.
+ *   3. Monte-Carlo loop: each case × N runs → runTarget (tiered model) →
+ *      gradeRun (code-first / judge) → aggregateCase (pass@k / pass^k /
+ *      variance). N is EVAL_RUNS (default 3, hard-clamped to <=5).
+ *   4. Writes agent-eval-result.json and (env-gated) publishes agent-eval:latest.
+ *
+ * FIDELITY NOTE: runTarget is a single generateText call with the rule as
+ * systemText — a PROXY for "the agent given this rule", not a full agent loop.
+ * The harness measures prompt-adherence, not end-to-end agent behavior.
+ *
+ * Run via: pnpm eval:agents  (TSX_TSCONFIG_PATH=scripts/tsconfig.eval.json).
+ */
+
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { AGENT_EVAL_CALIBRATION } from '@/evals/agents/calibration';
+import { loadCases } from '@/evals/agents/load';
+import { assertWithinBudget, MAX_JOB_COST_USD } from '@/lib/eval/budget';
+import {
+  CALIBRATION_ERROR_FRACTION_LIMIT,
+  MIN_CALIBRATION_AGREEMENT,
+  runCalibration,
+} from '@/lib/eval/calibration';
+import {
+  APPROX_FEATURE_INPUT_TOKENS,
+  APPROX_FEATURE_OUTPUT_TOKENS,
+  estimateJobCostUsd,
+  judgeCostUsdFrom,
+} from '@/lib/eval/cost';
+import { gradeRun } from '@/lib/eval/grade';
+import { aggregateCase, type CaseStats } from '@/lib/eval/montecarlo';
+import { publishAggregate } from '@/lib/eval/redis-publish';
+import { runTarget } from '@/lib/eval/run-target';
+import type { CalibrationResult } from '@/lib/eval/types';
+
+// Tiered models. Mechanical cases → haiku; judgment cases → sonnet. The judge
+// must be >= the model it grades, so it is sonnet regardless of tier.
+export const MODELS = {
+  mechanical: 'anthropic/claude-haiku-4-5',
+  judgment: 'anthropic/claude-sonnet-4-6',
+  judge: 'anthropic/claude-sonnet-4-6',
+} as const;
+
+// Redis key the aggregate publishes under. DISTINCT from ask:eval:latest — the
+// two harnesses must never collide on one key (C-d.1 pins this with a dedicated
+// test; the runner needs the constant now for the publishAggregate call).
+export const AGENT_EVAL_REDIS_KEY = 'agent-eval:latest';
+
+// Local artifact path — the JSON CI uploads for the run.
+const RESULT_FILE = path.resolve(process.cwd(), 'agent-eval-result.json');
+
+// Per-run count. EVAL_RUNS overrides the default 3; HARD-clamped to <=5 (and
+// >=1) so a typo can never blow the cost ceiling via an unbounded N.
+const DEFAULT_RUNS = 3;
+const MAX_RUNS = 5;
+export function resolveRuns(raw: string | undefined): number {
+  const parsed = Number(raw);
+  if (!raw || !Number.isFinite(parsed) || parsed < 1) return DEFAULT_RUNS;
+  return Math.min(MAX_RUNS, Math.floor(parsed));
+}
+
+export type AgentEvalAggregate = {
+  ts: string;
+  targetModelMechanical: string;
+  targetModelJudgment: string;
+  judgeModel: string;
+  runs: number;
+  calibration: {
+    total: number;
+    agreed: number;
+    agreement: number;
+    passed: boolean;
+    minAgreement: number;
+    errored: number;
+  };
+  cases: CaseStats[];
+  costEstimateUsd: number;
+  maxJobCostUsd: number;
+  gate: { calibrationPassed: boolean; withinBudget: boolean; passed: boolean };
+};
+
+/**
+ * Pure aggregate assembler. Folds the calibration result, per-case Monte-Carlo
+ * stats, the cost estimate, and the budget verdict into the published shape and
+ * computes the run-level gate: the run PASSES only when calibration passed AND
+ * the projection was within budget.
+ */
+export function buildAggregate(args: {
+  runs: number;
+  calibration: CalibrationResult;
+  caseStats: CaseStats[];
+  costEstimateUsd: number;
+  withinBudget: boolean;
+}): AgentEvalAggregate {
+  const calibrationPassed = args.calibration.passed;
+  return {
+    ts: new Date().toISOString(),
+    targetModelMechanical: MODELS.mechanical,
+    targetModelJudgment: MODELS.judgment,
+    judgeModel: MODELS.judge,
+    runs: args.runs,
+    calibration: {
+      total: args.calibration.total,
+      agreed: args.calibration.agreed,
+      agreement: args.calibration.agreement,
+      passed: calibrationPassed,
+      minAgreement: MIN_CALIBRATION_AGREEMENT,
+      errored: args.calibration.errored,
+    },
+    cases: args.caseStats,
+    costEstimateUsd: args.costEstimateUsd,
+    maxJobCostUsd: MAX_JOB_COST_USD,
+    gate: {
+      calibrationPassed,
+      withinBudget: args.withinBudget,
+      passed: calibrationPassed && args.withinBudget,
+    },
+  };
+}
+
+// Tiered target model for a case.
+function targetModelFor(tier: 'mechanical' | 'judgment'): string {
+  return tier === 'mechanical' ? MODELS.mechanical : MODELS.judgment;
+}
+
+async function main(): Promise<void> {
+  // Guard: AI_GATEWAY_API_KEY drives both the target and the judge. In CI a
+  // missing key is a hard failure (a silent exit 0 would let the job pass
+  // without running any eval); locally the key is often absent — exit 0.
+  if (!process.env.AI_GATEWAY_API_KEY) {
+    if (process.env.CI) {
+      console.error('agent-eval: AI_GATEWAY_API_KEY is required in CI but not set — aborting');
+      process.exit(1);
+    }
+    console.log('agent-eval skipped: AI_GATEWAY_API_KEY not configured');
+    process.exit(0);
+  }
+
+  const runs = resolveRuns(process.env.EVAL_RUNS);
+  const cases = await loadCases();
+
+  // ── Calibration FIRST ────────────────────────────────────────────────────
+  console.log(
+    `agent-eval: calibration — ${AGENT_EVAL_CALIBRATION.length} gold cases → judge ${MODELS.judge}\n`,
+  );
+  const calibration = await runCalibration(AGENT_EVAL_CALIBRATION, { model: MODELS.judge });
+
+  const calErrorFraction = calibration.total > 0 ? calibration.errored / calibration.total : 0;
+  const calibrationOutage = calErrorFraction > CALIBRATION_ERROR_FRACTION_LIMIT;
+  console.log(
+    `  agreement ${calibration.agreed}/${calibration.total} ` +
+      `(${(calibration.agreement * 100).toFixed(1)}%, min ${MIN_CALIBRATION_AGREEMENT * 100}%)`,
+  );
+
+  if (!calibration.passed) {
+    // Write a calibration-only result so CI uploads an inspectable artifact even
+    // though the corpus never ran. The corpus is intentionally skipped (cases
+    // empty), and the calibration judge spend is the only cost incurred.
+    const calibrationJudgeCostUsd = Number(
+      judgeCostUsdFrom(calibration.judgeInputTokens, calibration.judgeOutputTokens).toFixed(4),
+    );
+    const partial = buildAggregate({
+      runs,
+      calibration,
+      caseStats: [],
+      costEstimateUsd: calibrationJudgeCostUsd,
+      withinBudget: true,
+    });
+    writeFileSync(RESULT_FILE, `${JSON.stringify(partial, null, 2)}\n`);
+    if (calibrationOutage) {
+      console.error(
+        `\nCALIBRATION SKIPPED due to judge API failures (${calibration.errored}/${calibration.total} errored, ` +
+          `limit ${CALIBRATION_ERROR_FRACTION_LIMIT * 100}%) — an outage, not drift. Re-run when the Gateway is healthy.`,
+      );
+    } else {
+      console.error(
+        `\nCALIBRATION GATE FAILED — judge agreement ${(calibration.agreement * 100).toFixed(1)}% ` +
+          `(min ${MIN_CALIBRATION_AGREEMENT * 100}%). Inspect the disagreements before trusting any grade.`,
+      );
+    }
+    console.error(`result file (calibration-only) ${RESULT_FILE}`);
+    process.exit(1);
+  }
+  console.log('  CALIBRATION PASSED\n');
+
+  // ── Cost pre-flight ──────────────────────────────────────────────────────
+  // Project the corpus cost BEFORE any target/judge call and abort over the cap.
+  // The target side is approximated from the feature token constants; the judge
+  // side from the same approximation (judge graders read a comparable payload).
+  const projectedUsd = Number(
+    estimateJobCostUsd({
+      cases: cases.length,
+      runs,
+      approxTargetInputTokens: APPROX_FEATURE_INPUT_TOKENS,
+      approxTargetOutputTokens: APPROX_FEATURE_OUTPUT_TOKENS,
+      approxJudgeInputTokens: APPROX_FEATURE_INPUT_TOKENS,
+      approxJudgeOutputTokens: APPROX_FEATURE_OUTPUT_TOKENS,
+    }).toFixed(4),
+  );
+  const budget = assertWithinBudget({ projectedUsd, doubled: false });
+  if (!budget.ok) {
+    const aborted = buildAggregate({
+      runs,
+      calibration,
+      caseStats: [],
+      costEstimateUsd: projectedUsd,
+      withinBudget: false,
+    });
+    writeFileSync(RESULT_FILE, `${JSON.stringify(aborted, null, 2)}\n`);
+    console.error(`\nCOST CEILING EXCEEDED — ${budget.reason}`);
+    console.error(`result file (aborted) ${RESULT_FILE}`);
+    process.exit(1);
+  }
+  console.log(
+    `agent-eval: ${cases.length} cases × ${runs} runs (projected ~$${projectedUsd}, cap $${MAX_JOB_COST_USD})\n`,
+  );
+
+  // ── Monte-Carlo loop ─────────────────────────────────────────────────────
+  const caseStats: CaseStats[] = [];
+  for (const c of cases) {
+    const targetModel = targetModelFor(c.tier);
+    const runResults: boolean[] = [];
+    for (let i = 0; i < runs; i++) {
+      const target = await runTarget(c, { model: targetModel });
+      if (target.errored) {
+        // A target invocation failure is a non-passing run, recorded not dropped.
+        runResults.push(false);
+        console.log(`  ERROR [${c.tier}] ${c.id} run ${i + 1}/${runs} — ${target.detail}`);
+        continue;
+      }
+      const verdict = await gradeRun(c, target.output, { judgeModel: MODELS.judge });
+      runResults.push(verdict.pass);
+      console.log(
+        `  ${verdict.pass ? 'PASS' : 'FAIL'} [${c.tier}] ${c.id} run ${i + 1}/${runs} — ${verdict.reason}`,
+      );
+    }
+    const stats = aggregateCase(c.id, runResults);
+    caseStats.push(stats);
+    console.log(
+      `  ${c.id}: pass@k=${stats.passAtK} pass^k=${stats.passHatK} mean=${stats.mean.toFixed(2)} var=${stats.variance.toFixed(3)}\n`,
+    );
+  }
+
+  const aggregate = buildAggregate({
+    runs,
+    calibration,
+    caseStats,
+    costEstimateUsd: projectedUsd,
+    withinBudget: true,
+  });
+
+  writeFileSync(RESULT_FILE, `${JSON.stringify(aggregate, null, 2)}\n`);
+
+  const publishResult = await publishAggregate(AGENT_EVAL_REDIS_KEY, aggregate);
+  if (publishResult.published) {
+    console.log(`\npublished aggregate → redis ${AGENT_EVAL_REDIS_KEY}`);
+  } else if (publishResult.error) {
+    console.error(`\nredis publish failed (non-fatal): ${publishResult.error}`);
+  }
+
+  console.log('\nagent-eval summary');
+  for (const s of caseStats) {
+    console.log(
+      `  ${s.id.padEnd(28)} pass@k ${s.passAtK} · pass^k ${s.passHatK} · var ${s.variance.toFixed(3)}`,
+    );
+  }
+  console.log(`  cost estimate       ~$${aggregate.costEstimateUsd} (cap $${MAX_JOB_COST_USD})`);
+  console.log(`  result file         ${RESULT_FILE}`);
+  console.log('\nGATE PASSED');
+}
+
+// Entrypoint guard: run main() ONLY when this file is the process entrypoint
+// (pnpm eval:agents), never when it is imported by a unit test for buildAggregate
+// / the exported constants. Without this, importing the module would launch the
+// full I/O loop under Vitest.
+const invokedDirectly =
+  typeof process.argv[1] === 'string' && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('agent-eval: fatal error', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Sub-PR **C-b** of Unit C → integration branch `feat/platform-gaps-2026-agent-eval`. Builds the Monte-Carlo runner on top of C-a's shared `lib/eval/` core: `pnpm eval:agents` runs the agent corpus N times, grades each run (code-first, then the calibrated shared judge), and aggregates pass@k / pass^k / variance — with calibration gating the run and a hard cost ceiling enforced before any model call.

- **Monte-Carlo aggregation** (`lib/eval/montecarlo.ts`): `passAtK` (P≥1 pass, discrimination), `passHatK` (P all pass, consistency), mean, population variance, stddev.
- **Calibration gate FIRST** (`lib/eval/calibration.ts` + `evals/agents/calibration.ts` gold set): runs before the corpus, reuses the **shared** `judge()` (one-judge-prompt invariant), gates on `MIN_CALIBRATION_AGREEMENT=0.85` / `CALIBRATION_ERROR_FRACTION_LIMIT=0.5`; a drifted judge fails the run before spending corpus tokens.
- **Cost ceiling** (`lib/eval/budget.ts`): `MAX_JOB_COST_USD=2.0`; the runner projects cost and **aborts before the first corpus model call** if over cap. `EVAL_RUNS` (default 3) is hard-clamped to ≤5.
- **Target invocation + grading** (`run-target.ts`, `grade.ts`): one `generateText` per run (tiered model); code graders run `assert()` for free and never invoke the judge; judge graders use the shared judge.
- **Runner** (`scripts/agent-eval.ts` + `eval:agents`): `AI_GATEWAY_API_KEY` guard (CI hard-fail / local exit 0), calibration → cost pre-flight → Monte-Carlo loop → `agent-eval-result.json` → env-gated publish to the **distinct** `agent-eval:latest` key. `import.meta.url` entrypoint guard so unit tests can import `buildAggregate` without launching `main()`.
- **Integration smoke** (`__tests__/agent-eval-integration.test.ts`): mocks the `ai` SDK at the module boundary (no real Gateway call) and asserts the spec §5 acceptance — trivial `git-add-scoping` case 5/5 (`passAtK=1, passHatK=1, variance=0`), calibration scores good/bad (`agreement=1.0`), and a weakened target yields `passHatK<1` (the eval discriminates a flaky prompt).

## Type of change

- [x] `feat` — eval-harness runner (ships nothing to the app)

## Test plan

- [x] `pnpm test --run lib/eval evals/agents __tests__/agent-eval-*` — **16 files, 72 tests pass**
- [x] `pnpm typecheck` clean · `biome check` clean (1 pre-existing unrelated fixture warning)
- [x] Integration test mocks the SDK (zero Gateway calls); trivial case 100%, knownHard does not saturate, cost-cap aborts over budget (unit-tested)
- [x] 5-agent battery clean — code-reviewer **CLEAN** (all 8 load-bearing invariants verified: calibration-first gate order, cost-cap-before-model-call, N≤5 clamp, MC variance, code-first grading, distinct Redis key), security **SAFE** (key never logged, no secret in aggregate/result), perf/deps/a11y zero

## Visual changes

None — dev/CI tooling only.

## Checklist

- [x] Bundle impact — none (nothing in `app/` imports `lib/eval`)
- [x] A11y impact — none
- [x] ADR — deferred to C-d per the plan (the unit ADR lands with the CI sub-PR)

## Notes

- **Reviewed incrementally** as a sub-PR into the integration branch; the `feat/platform-gaps-2026-agent-eval` → `main` PR follows after C-c/C-d.
- **Deviation (mechanical, sound):** the plan's literal C-b.1 commit subject `feat(eval): Monte-Carlo …` was rejected by the repo's commitlint `subject-case` rule (capitalized lead word); the implementer prepended `add` → `feat(eval): add Monte-Carlo …`. Only that one subject was affected; no code change.
- **Non-blocking note (review):** calibration judge spend runs before the corpus cost-cap check, so it is not counted against `MAX_JOB_COST_USD` — a deliberate, bounded (gold-set-sized) design choice; reported separately as `calibrationJudgeCostUsd`.
- **Deferred per plan:** ask-eval.ts's own `runCalibration()` is NOT re-pointed at the generalized `lib/eval/calibration.ts` here (C-b.3 plan note) — the shared `judge()` already guarantees the one-judge-prompt property.
