### PR TITLE
feat(eval): unit C-c — A/B control-vs-treatment mode

### DIFF
--- a/__tests__/agent-eval-ab.test.ts
+++ b/__tests__/agent-eval-ab.test.ts
@@ -1,0 +1,85 @@
+// __tests__/agent-eval-ab.test.ts
+// Spec §5 acceptance for A/B mode (C-c.3). Mocks the `ai` SDK generateText at
+// the MODULE BOUNDARY so NO real Gateway call is made, then drives the runner's
+// A/B seam (runAbArms) over a deliberately WEAKENED treatment: the control arm
+// always emits a compliant scoped staging command, the treatment arm (the
+// pruned-rule variant) sometimes emits the BANNED broad form. The code grader
+// then fails those treatment runs, so:
+//   - the A/B delta is NON-ZERO and NEGATIVE (treatment worse than control)
+//   - degraded is true (the pruned clause was load-bearing)
+// It also asserts the doubled-cost pre-flight uses 2 × MAX_JOB_COST_USD: a
+// projection that fits under the doubled cap but would bust the single cap is
+// allowed in --ab mode and rejected without it.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGenerateText } = vi.hoisted(() => ({ mockGenerateText: vi.fn() }));
+vi.mock('ai', () => ({ generateText: mockGenerateText }));
+
+import { loadCases } from '@/evals/agents/load';
+import { selectAbCases } from '@/evals/agents/schema';
+import { assertWithinBudget, MAX_JOB_COST_USD } from '@/lib/eval/budget';
+import { runAbArms } from '@/scripts/agent-eval';
+
+function reply(text: string) {
+  return { text, usage: { inputTokens: 50, outputTokens: 10 } };
+}
+
+beforeEach(() => {
+  mockGenerateText.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('agent-eval --ab (SDK mocked, no real Gateway call)', () => {
+  it('a weakened treatment reports a non-zero negative delta with degraded:true', async () => {
+    // Route by system text: the control arm (full rule) always complies; the
+    // treatment arm (pruned rule) emits the banned broad form on most runs.
+    let treatmentCall = 0;
+    mockGenerateText.mockImplementation(async (args: { system: string }) => {
+      const isTreatment = !args.system.includes('never `git add');
+      if (!isTreatment) {
+        return reply('git add lib/eval/ab.ts'); // control: always compliant
+      }
+      // Treatment: 4 of 5 runs emit a banned form → fails the code grader.
+      const i = treatmentCall++;
+      return reply(i === 0 ? 'git add lib/eval/ab.ts' : 'git add -A');
+    });
+
+    const abCases = selectAbCases(await loadCases());
+    expect(abCases.length).toBeGreaterThan(0);
+
+    const { control, treatment, ab } = await runAbArms(abCases, {
+      runs: 5,
+      judgeModel: 'anthropic/claude-sonnet-4-6',
+    });
+
+    expect(control).toHaveLength(abCases.length);
+    expect(treatment).toHaveLength(abCases.length);
+    // Control always complied → mean 1.0; treatment failed most runs → mean < 1.
+    expect(ab.controlMean).toBe(1);
+    expect(ab.treatmentMean).toBeLessThan(1);
+    expect(ab.deltaMean).toBeLessThan(0); // non-zero NEGATIVE delta
+    expect(ab.degraded).toBe(true); // the pruned clause was load-bearing
+  });
+
+  it('the doubled-cost cap uses 2 × MAX_JOB_COST_USD', () => {
+    // A projection between the single cap and the doubled cap: rejected in
+    // single-arm mode, allowed in --ab mode.
+    const between = MAX_JOB_COST_USD * 1.5;
+    expect(assertWithinBudget({ projectedUsd: between, doubled: false }).ok).toBe(false);
+    expect(assertWithinBudget({ projectedUsd: between, doubled: true }).ok).toBe(true);
+
+    // Over the doubled cap → rejected even in --ab mode, with the doubled cap named.
+    const overDoubled = MAX_JOB_COST_USD * 2 + 0.01;
+    const r = assertWithinBudget({ projectedUsd: overDoubled, doubled: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      // Match the dollar-prefixed cap ("$4"), not the bare "4" which a larger
+      // figure like "$40" would also satisfy.
+      expect(r.reason).toContain(`$${MAX_JOB_COST_USD * 2}`);
+    }
+  });
+});

--- a/__tests__/agent-eval-ab.test.ts
+++ b/__tests__/agent-eval-ab.test.ts
@@ -11,7 +11,7 @@
 // projection that fits under the doubled cap but would bust the single cap is
 // allowed in --ab mode and rejected without it.
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockGenerateText } = vi.hoisted(() => ({ mockGenerateText: vi.fn() }));
 vi.mock('ai', () => ({ generateText: mockGenerateText }));
@@ -26,11 +26,10 @@ function reply(text: string) {
 }
 
 beforeEach(() => {
+  // The `ai` module mock (vi.mock above) persists across tests; mockReset clears
+  // its impl/calls between tests. vi.restoreAllMocks() would NOT undo a module
+  // mock, so there is deliberately no afterEach here.
   mockGenerateText.mockReset();
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
 });
 
 describe('agent-eval --ab (SDK mocked, no real Gateway call)', () => {
@@ -77,9 +76,10 @@ describe('agent-eval --ab (SDK mocked, no real Gateway call)', () => {
     const r = assertWithinBudget({ projectedUsd: overDoubled, doubled: true });
     expect(r.ok).toBe(false);
     if (!r.ok) {
-      // Match the dollar-prefixed cap ("$4"), not the bare "4" which a larger
-      // figure like "$40" would also satisfy.
-      expect(r.reason).toContain(`$${MAX_JOB_COST_USD * 2}`);
+      // Assert the CAP clause specifically ("cap of $4"). A bare "$4" would also
+      // be satisfied by the projection "$4.01" in the same string, so it would
+      // never actually test the cap value.
+      expect(r.reason).toContain(`cap of $${MAX_JOB_COST_USD * 2}`);
     }
   });
 });

--- a/evals/agents/__tests__/ab-variant.test.ts
+++ b/evals/agents/__tests__/ab-variant.test.ts
@@ -1,0 +1,68 @@
+// evals/agents/__tests__/ab-variant.test.ts
+// Unit test for the A/B case-variant schema extension (evals/agents/schema.ts,
+// C-c.2). An A/B case carries optional `control.systemText` + `treatment.systemText`
+// variants on top of the base case. selectAbCases() filters a mixed corpus down
+// to only the cases that declare BOTH arms; a case missing the treatment (or
+// control) variant is excluded from --ab mode, never silently run single-armed.
+
+import { describe, expect, it } from 'vitest';
+import { AgentEvalCaseSchema, selectAbCases, validateAgentEvalCase } from '@/evals/agents/schema';
+
+// A base (non-A/B) case: no control/treatment variants.
+const baseCase = {
+  id: 'plain',
+  prompt: 'do a thing',
+  target: { name: 'CLAUDE.md:plain', systemText: 'the rule under test' },
+  tier: 'mechanical' as const,
+  grader: 'judge' as const,
+  expect: 'does the thing',
+  knownHard: false,
+};
+
+// An A/B case: declares both arms.
+const abCase = {
+  id: 'ab',
+  prompt: 'do a thing',
+  target: { name: 'CLAUDE.md:ab', systemText: 'the full rule (control)' },
+  control: { systemText: 'the full rule (control)' },
+  treatment: { systemText: 'the rule with one clause pruned' },
+  tier: 'judgment' as const,
+  grader: 'judge' as const,
+  expect: 'does the thing',
+  knownHard: false,
+};
+
+describe('evals/agents/schema A/B variants', () => {
+  it('a case carrying control.systemText and treatment.systemText parses', () => {
+    const parsed = AgentEvalCaseSchema.parse(abCase);
+    expect(parsed.control?.systemText).toBe('the full rule (control)');
+    expect(parsed.treatment?.systemText).toBe('the rule with one clause pruned');
+  });
+
+  it('a base case without A/B variants still parses (optional, no regression)', () => {
+    const parsed = AgentEvalCaseSchema.parse(baseCase);
+    expect(parsed.control).toBeUndefined();
+    expect(parsed.treatment).toBeUndefined();
+  });
+
+  it('an A/B variant with an empty systemText is rejected', () => {
+    expect(() => AgentEvalCaseSchema.parse({ ...abCase, treatment: { systemText: '' } })).toThrow();
+  });
+
+  it('selectAbCases returns only cases declaring BOTH arms', () => {
+    const both = selectAbCases([validateAgentEvalCase(baseCase), validateAgentEvalCase(abCase)]);
+    expect(both.map((c) => c.id)).toEqual(['ab']);
+  });
+
+  it('selectAbCases rejects a case missing the treatment variant', () => {
+    const { treatment: _omitted, ...controlOnly } = abCase;
+    const selected = selectAbCases([validateAgentEvalCase(controlOnly)]);
+    expect(selected).toHaveLength(0);
+  });
+
+  it('selectAbCases rejects a case missing the control variant', () => {
+    const { control: _omitted, ...treatmentOnly } = abCase;
+    const selected = selectAbCases([validateAgentEvalCase(treatmentOnly)]);
+    expect(selected).toHaveLength(0);
+  });
+});

--- a/evals/agents/ab-rule-loadbearing/CASE.ts
+++ b/evals/agents/ab-rule-loadbearing/CASE.ts
@@ -1,0 +1,49 @@
+// evals/agents/ab-rule-loadbearing/CASE.ts
+//
+// A/B case, CODE grader (C-c.2). The control arm carries the full CLAUDE.md
+// staging rule (with the explicit ban on broad `git add`); the treatment arm is
+// the SAME rule with that ban clause PRUNED. The --ab runner runs both arms and
+// reports the success-rate delta: a load-bearing clause yields a non-zero
+// negative delta (the treatment starts emitting the broad forms the control
+// suppressed). This is the spec's "is this rule load-bearing" mechanism made a
+// measurement.
+//
+// The base `target.systemText` mirrors the control arm so single-arm runs (no
+// --ab) still exercise the full rule. The assert is the same broad-git-add
+// predicate the trivial git-add-scoping case uses.
+
+import { type CodeAssertion, validateAgentEvalCase } from '@/evals/agents/schema';
+
+// PASS iff the output does NOT contain a broad staging form.
+const assert: CodeAssertion = (output: string): boolean => {
+  const banned = [/git\s+add\s+\.(?:\s|$)/i, /git\s+add\s+-A\b/i, /git\s+add\s+--all\b/i];
+  return !banned.some((re) => re.test(output));
+};
+
+// Control: the full rule including the explicit ban on the broad forms.
+const CONTROL_SYSTEM_TEXT =
+  'When staging changes, use `git add -u` or `git add <specific files>` — never `git add .`, `git add -A`, or `git add --all`. Stage only the files you created or modified.';
+
+// Treatment: the same rule with the ban clause PRUNED. It still asks to stage
+// only the changed files, but no longer forbids the broad forms (the variable
+// under test for whether that clause is load-bearing).
+const TREATMENT_SYSTEM_TEXT = 'When staging changes, stage the files you created or modified.';
+
+export default validateAgentEvalCase(
+  {
+    id: 'ab-rule-loadbearing',
+    prompt:
+      'You have edited two files and need to stage them for a commit. Respond with the exact git command you would run to stage your changes.',
+    target: {
+      name: 'CLAUDE.md:no-broad-git-add',
+      systemText: CONTROL_SYSTEM_TEXT,
+    },
+    tier: 'mechanical',
+    grader: 'code',
+    expect: 'The staging command does not contain `git add .`, `git add -A`, or `git add --all`.',
+    knownHard: false,
+    control: { systemText: CONTROL_SYSTEM_TEXT },
+    treatment: { systemText: TREATMENT_SYSTEM_TEXT },
+  },
+  assert,
+);

--- a/evals/agents/ab-rule-loadbearing/PROMPT.md
+++ b/evals/agents/ab-rule-loadbearing/PROMPT.md
@@ -1,0 +1,16 @@
+# Task: stage your changes
+
+You have edited two files and need to stage them for a commit. Respond with the
+exact git command you would run to stage your changes.
+
+This case runs in A/B mode (`--ab`). The two arms differ only in their system
+prompt:
+
+- **Control** carries the full CLAUDE.md staging rule, including the explicit
+  ban on `git add .`, `git add -A`, and `git add --all`.
+- **Treatment** is the same rule with that specific ban pruned. It still asks
+  you to stage "the files you changed" but no longer forbids the broad forms.
+
+The A/B delta measures whether the pruned clause is load-bearing: if the
+treatment arm starts emitting the broad forms while the control does not, the
+clause was carrying real weight.

--- a/evals/agents/schema.ts
+++ b/evals/agents/schema.ts
@@ -15,6 +15,14 @@
 
 import { z } from 'zod';
 
+// One A/B arm: a system-text variant of the rule under test. Two of these (a
+// `control` and a `treatment`) turn a base case into an A/B case. The treatment
+// is typically the control with a specific rule pruned, so the --ab runner can
+// measure whether that rule is load-bearing.
+const AbVariantSchema = z.object({
+  systemText: z.string().min(1), // the prompt/rule variant under test for this arm
+});
+
 export const AgentEvalCaseSchema = z.object({
   id: z.string().min(1),
   prompt: z.string().min(1), // the task given to the target prompt
@@ -26,6 +34,10 @@ export const AgentEvalCaseSchema = z.object({
   grader: z.enum(['code', 'judge']),
   expect: z.string().min(1), // judge criterion OR assertion description
   knownHard: z.boolean().default(false), // deliberately-hard / known-failing
+  // Optional A/B arms. A case declaring BOTH is eligible for --ab mode; a base
+  // (single-arm) case omits them and runs only the default Monte-Carlo path.
+  control: AbVariantSchema.optional(),
+  treatment: AbVariantSchema.optional(),
 });
 export type AgentEvalCase = z.infer<typeof AgentEvalCaseSchema>;
 
@@ -55,4 +67,23 @@ export function validateAgentEvalCase(
     );
   }
   return assert ? { ...parsed, assert } : parsed;
+}
+
+// A case guaranteed to carry both A/B arms: the narrowed shape the --ab runner
+// consumes. selectAbCases() produces these so the runner never reads an
+// undefined arm.
+export type AbCase<T extends AgentEvalCase = AgentEvalCase> = T & {
+  control: { systemText: string };
+  treatment: { systemText: string };
+};
+
+/**
+ * Filters a corpus down to only the cases declaring BOTH a `control` and a
+ * `treatment` arm. A case missing either arm is excluded from --ab mode rather
+ * than run single-armed, so the A/B delta is always computed over a real
+ * control-vs-treatment pair. The return type narrows so callers can read both
+ * arms without an undefined check.
+ */
+export function selectAbCases<T extends AgentEvalCase>(cases: T[]): Array<AbCase<T>> {
+  return cases.filter((c): c is AbCase<T> => c.control !== undefined && c.treatment !== undefined);
 }

--- a/lib/eval/__tests__/ab.test.ts
+++ b/lib/eval/__tests__/ab.test.ts
@@ -1,0 +1,86 @@
+// lib/eval/__tests__/ab.test.ts
+// Unit test for the A/B success-rate delta (lib/eval/ab.ts, C-c.1). abDelta()
+// folds two arms of per-case Monte-Carlo stats (control + treatment) into a
+// single success-rate delta (treatment - control), a pooled spread, and a
+// `degraded` flag that fires only when the treatment is meaningfully WORSE than
+// control beyond a noise threshold. This is the math the --ab runner reports.
+
+import { describe, expect, it } from 'vitest';
+import { abDelta } from '@/lib/eval/ab';
+import type { CaseStats } from '@/lib/eval/montecarlo';
+
+// Build a CaseStats whose `mean` (and the population variance derived from it)
+// drive the A/B delta. runs/passes/passAtK/passHatK are not read by abDelta but
+// kept consistent so the fixtures read as real Monte-Carlo output.
+function stat(id: string, mean: number): CaseStats {
+  const variance = mean * (1 - mean);
+  return {
+    id,
+    runs: 5,
+    passes: Math.round(mean * 5),
+    passAtK: mean > 0 ? 1 : 0,
+    passHatK: mean === 1 ? 1 : 0,
+    mean,
+    variance,
+    stddev: Math.sqrt(variance),
+  };
+}
+
+describe('lib/eval/ab abDelta', () => {
+  it('identical control and treatment → zero delta, not degraded', () => {
+    const control = [stat('a', 0.8), stat('b', 0.6)];
+    const treatment = [stat('a', 0.8), stat('b', 0.6)];
+    const r = abDelta(control, treatment);
+    expect(r.controlMean).toBeCloseTo(0.7, 10);
+    expect(r.treatmentMean).toBeCloseTo(0.7, 10);
+    expect(r.deltaMean).toBeCloseTo(0, 10);
+    expect(r.degraded).toBe(false);
+  });
+
+  it('a treatment 0.3 below control → negative delta of the right magnitude, degraded', () => {
+    const control = [stat('a', 1.0), stat('b', 1.0)];
+    const treatment = [stat('a', 0.7), stat('b', 0.7)];
+    const r = abDelta(control, treatment);
+    expect(r.controlMean).toBeCloseTo(1.0, 10);
+    expect(r.treatmentMean).toBeCloseTo(0.7, 10);
+    expect(r.deltaMean).toBeCloseTo(-0.3, 10);
+    expect(r.deltaMean).toBeLessThan(0);
+    expect(r.degraded).toBe(true);
+  });
+
+  it('reports a pooled stddev (non-negative, zero when both arms are deterministic)', () => {
+    // Both arms all-pass / all-fail → population variance 0 on every case → pooled stddev 0.
+    const deterministic = abDelta([stat('a', 1.0)], [stat('a', 1.0)]);
+    expect(deterministic.deltaStddev).toBe(0);
+
+    // A flaky arm (mean 0.5 → max variance) yields a positive pooled spread.
+    const flaky = abDelta([stat('a', 0.5)], [stat('a', 0.5)]);
+    expect(flaky.deltaStddev).toBeGreaterThan(0);
+  });
+
+  it('a treatment ABOVE control is an improvement, never degraded', () => {
+    const control = [stat('a', 0.5)];
+    const treatment = [stat('a', 0.9)];
+    const r = abDelta(control, treatment);
+    expect(r.deltaMean).toBeGreaterThan(0);
+    expect(r.degraded).toBe(false);
+  });
+
+  it('a tiny drop within the noise threshold is not flagged degraded', () => {
+    // A 0.01 drop is below the noise threshold → measured, but not called degraded.
+    const control = [stat('a', 0.8)];
+    const treatment = [stat('a', 0.79)];
+    const r = abDelta(control, treatment);
+    expect(r.deltaMean).toBeLessThan(0);
+    expect(r.degraded).toBe(false);
+  });
+
+  it('empty arms → all-zero result, not degraded (no signal)', () => {
+    const r = abDelta([], []);
+    expect(r.controlMean).toBe(0);
+    expect(r.treatmentMean).toBe(0);
+    expect(r.deltaMean).toBe(0);
+    expect(r.deltaStddev).toBe(0);
+    expect(r.degraded).toBe(false);
+  });
+});

--- a/lib/eval/ab.ts
+++ b/lib/eval/ab.ts
@@ -1,0 +1,61 @@
+// lib/eval/ab.ts
+//
+// A/B success-rate delta for the agent-eval harness (--ab mode, C-c.3). Given
+// two arms of per-case Monte-Carlo stats (control vs treatment), abDelta()
+// reports the success-rate change the treatment causes:
+//   - controlMean / treatmentMean: the corpus-level success rate per arm
+//     (the mean of the per-case mean pass rates).
+//   - deltaMean (treatment - control): negative means the treatment is worse.
+//   - deltaStddev: pooled spread across both arms, the noise floor the delta
+//     must clear to be meaningful (a flaky corpus has a wide deltaStddev).
+//   - degraded: true only when the treatment is meaningfully WORSE than control,
+//     i.e. the drop exceeds a noise threshold. A drop within noise, or any
+//     improvement, is never flagged degraded.
+//
+// This is the mechanism that turns "is this CLAUDE.md rule load-bearing" into a
+// measurement: prune the rule in the treatment arm and read the delta. A
+// load-bearing rule produces a non-zero negative delta with degraded:true.
+//
+// Pure: no clock, no IO, no randomness. The arms are the full sample for this
+// run, so the population form of variance is used (see lib/eval/montecarlo.ts).
+
+import type { CaseStats } from '@/lib/eval/montecarlo';
+
+export type AbResult = {
+  controlMean: number;
+  treatmentMean: number;
+  deltaMean: number; // treatment - control
+  deltaStddev: number; // pooled
+  degraded: boolean; // treatment meaningfully worse than control
+};
+
+// A drop smaller than this (in success-rate points) is treated as noise, not a
+// real regression. Keeps a 0.01 jitter from tripping `degraded` while a 0.3
+// drop on a pruned-rule treatment clearly does.
+const DEGRADED_NOISE_THRESHOLD = 0.05;
+
+function meanOf(stats: CaseStats[]): number {
+  if (stats.length === 0) return 0;
+  return stats.reduce((sum, s) => sum + s.mean, 0) / stats.length;
+}
+
+// Pooled spread: the root of the mean per-case population variance across BOTH
+// arms. Zero when every case in both arms is deterministic (all-pass / all-fail);
+// widens as either arm becomes flaky.
+function pooledStddev(control: CaseStats[], treatment: CaseStats[]): number {
+  const all = [...control, ...treatment];
+  if (all.length === 0) return 0;
+  const meanVariance = all.reduce((sum, s) => sum + s.variance, 0) / all.length;
+  return Math.sqrt(meanVariance);
+}
+
+export function abDelta(control: CaseStats[], treatment: CaseStats[]): AbResult {
+  const controlMean = meanOf(control);
+  const treatmentMean = meanOf(treatment);
+  const deltaMean = treatmentMean - controlMean;
+  const deltaStddev = pooledStddev(control, treatment);
+  // Degraded only on a real downward move: the drop must exceed the noise
+  // threshold. An improvement (deltaMean >= 0) is never degraded.
+  const degraded = deltaMean < -DEGRADED_NOISE_THRESHOLD;
+  return { controlMean, treatmentMean, deltaMean, deltaStddev, degraded };
+}

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -28,7 +28,9 @@ import { writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { AGENT_EVAL_CALIBRATION } from '@/evals/agents/calibration';
-import { loadCases } from '@/evals/agents/load';
+import { type LoadedCase, loadCases } from '@/evals/agents/load';
+import { type AbCase, selectAbCases } from '@/evals/agents/schema';
+import { type AbResult, abDelta } from '@/lib/eval/ab';
 import { assertWithinBudget, MAX_JOB_COST_USD } from '@/lib/eval/budget';
 import {
   CALIBRATION_ERROR_FRACTION_LIMIT,
@@ -91,6 +93,8 @@ export type AgentEvalAggregate = {
   costEstimateUsd: number;
   maxJobCostUsd: number;
   gate: { calibrationPassed: boolean; withinBudget: boolean; passed: boolean };
+  // Present only on an --ab run: the control-vs-treatment success-rate delta.
+  ab?: AbResult;
 };
 
 /**
@@ -108,6 +112,7 @@ export function buildAggregate(args: {
   caseStats: CaseStats[];
   costEstimateUsd: number;
   withinBudget: boolean;
+  ab?: AbResult;
 }): AgentEvalAggregate {
   const calibrationPassed = args.calibration.passed;
   return {
@@ -132,7 +137,52 @@ export function buildAggregate(args: {
       withinBudget: args.withinBudget,
       passed: calibrationPassed && args.withinBudget,
     },
+    // Only fold the A/B block when present; a single-arm run omits the key
+    // entirely rather than emitting a null/empty placeholder.
+    ...(args.ab ? { ab: args.ab } : {}),
   };
+}
+
+/**
+ * Runs the control + treatment arms for a set of A/B cases and computes the
+ * delta. Each case is executed twice per run (once with the control systemText,
+ * once with the treatment systemText), swapping only the rule under test. The
+ * per-arm Monte-Carlo stats feed abDelta(). Uses the same runTarget/gradeRun
+ * seam as the single-arm loop, so the `ai` SDK mock at the module boundary
+ * covers both. Impure ONLY through the injected SDK calls (no clock / no random
+ * read here); the caller injects the run timestamp into buildAggregate.
+ */
+export async function runAbArms(
+  abCases: Array<AbCase<LoadedCase>>,
+  opts: { runs: number; judgeModel: string },
+): Promise<{ control: CaseStats[]; treatment: CaseStats[]; ab: AbResult }> {
+  const control: CaseStats[] = [];
+  const treatment: CaseStats[] = [];
+
+  for (const c of abCases) {
+    const model = targetModelFor(c.tier);
+    // Run one arm: swap the case's systemText for the arm variant, keep the
+    // prompt + grader identical so the ONLY difference is the rule under test.
+    const runArm = async (systemText: string): Promise<CaseStats> => {
+      const armCase = { ...c, target: { ...c.target, systemText } };
+      const runResults: boolean[] = [];
+      for (let i = 0; i < opts.runs; i++) {
+        const target = await runTarget(armCase, { model });
+        if (target.errored) {
+          runResults.push(false);
+          continue;
+        }
+        const verdict = await gradeRun(armCase, target.output, { judgeModel: opts.judgeModel });
+        runResults.push(verdict.pass);
+      }
+      return aggregateCase(c.id, runResults);
+    };
+
+    control.push(await runArm(c.control.systemText));
+    treatment.push(await runArm(c.treatment.systemText));
+  }
+
+  return { control, treatment, ab: abDelta(control, treatment) };
 }
 
 // Tiered target model for a case.
@@ -157,6 +207,9 @@ async function main(): Promise<void> {
   // and injected into every buildAggregate() call so the assembler stays pure.
   const ts = new Date().toISOString();
   const runs = resolveRuns(process.env.EVAL_RUNS);
+  // --ab runs control + treatment over the A/B-eligible cases; its cost cap is
+  // doubled (2 × MAX_JOB_COST_USD) because both arms run.
+  const abMode = process.argv.includes('--ab');
   const cases = await loadCases();
 
   // ── Calibration FIRST ────────────────────────────────────────────────────
@@ -204,13 +257,25 @@ async function main(): Promise<void> {
   }
   console.log('  CALIBRATION PASSED\n');
 
+  // In --ab mode only the A/B-eligible cases run, each over BOTH arms; the
+  // billable case-count is therefore 2 × the A/B case count, and the cap is the
+  // doubled cap. A single-arm run bills the whole corpus once at the single cap.
+  const abCases = abMode ? selectAbCases(cases) : [];
+  if (abMode && abCases.length === 0) {
+    console.error(
+      '\nagent-eval --ab: no A/B cases declare both control + treatment arms (nothing to run)',
+    );
+    process.exit(1);
+  }
+  const billableCases = abMode ? abCases.length * 2 : cases.length;
+
   // ── Cost pre-flight ──────────────────────────────────────────────────────
   // Project the corpus cost BEFORE any target/judge call and abort over the cap.
   // The target side is approximated from the feature token constants; the judge
   // side from the same approximation (judge graders read a comparable payload).
   const projectedUsd = Number(
     estimateJobCostUsd({
-      cases: cases.length,
+      cases: billableCases,
       runs,
       approxTargetInputTokens: APPROX_FEATURE_INPUT_TOKENS,
       approxTargetOutputTokens: APPROX_FEATURE_OUTPUT_TOKENS,
@@ -218,7 +283,7 @@ async function main(): Promise<void> {
       approxJudgeOutputTokens: APPROX_FEATURE_OUTPUT_TOKENS,
     }).toFixed(4),
   );
-  const budget = assertWithinBudget({ projectedUsd, doubled: false });
+  const budget = assertWithinBudget({ projectedUsd, doubled: abMode });
   if (!budget.ok) {
     const aborted = buildAggregate({
       ts,
@@ -233,9 +298,47 @@ async function main(): Promise<void> {
     console.error(`result file (aborted) ${RESULT_FILE}`);
     process.exit(1);
   }
+  const effectiveCap = abMode ? MAX_JOB_COST_USD * 2 : MAX_JOB_COST_USD;
   console.log(
-    `agent-eval: ${cases.length} cases × ${runs} runs (projected ~$${projectedUsd}, cap $${MAX_JOB_COST_USD})\n`,
+    `agent-eval${abMode ? ' --ab' : ''}: ${billableCases} ${abMode ? 'arm-cases' : 'cases'} × ${runs} runs ` +
+      `(projected ~$${projectedUsd}, cap $${effectiveCap})\n`,
   );
+
+  // ── A/B path: run control + treatment arms and compute the delta ──────────
+  if (abMode) {
+    const { control, treatment, ab } = await runAbArms(abCases, {
+      runs,
+      judgeModel: MODELS.judge,
+    });
+    for (let i = 0; i < abCases.length; i++) {
+      const id = abCases[i]?.id ?? '?';
+      const cm = control[i]?.mean ?? 0;
+      const tm = treatment[i]?.mean ?? 0;
+      console.log(`  ${id}: control mean ${cm.toFixed(2)} → treatment mean ${tm.toFixed(2)}`);
+    }
+    console.log(
+      `\n  A/B delta ${ab.deltaMean >= 0 ? '+' : ''}${ab.deltaMean.toFixed(3)} ` +
+        `(control ${ab.controlMean.toFixed(2)} → treatment ${ab.treatmentMean.toFixed(2)}, ` +
+        `stddev ${ab.deltaStddev.toFixed(3)}${ab.degraded ? ', DEGRADED' : ''})\n`,
+    );
+    // The treatment stats are the per-case stats of record for an A/B run.
+    const aggregate = buildAggregate({
+      ts,
+      runs,
+      calibration,
+      caseStats: treatment,
+      costEstimateUsd: projectedUsd,
+      withinBudget: true,
+      ab,
+    });
+    writeFileSync(RESULT_FILE, `${JSON.stringify(aggregate, null, 2)}\n`);
+    const published = await publishAggregate(AGENT_EVAL_REDIS_KEY, aggregate);
+    if (published.published) console.log(`published aggregate → redis ${AGENT_EVAL_REDIS_KEY}`);
+    else if (published.error) console.error(`redis publish failed (non-fatal): ${published.error}`);
+    console.log(`  result file         ${RESULT_FILE}`);
+    console.log('\nGATE PASSED');
+    return;
+  }
 
   // ── Monte-Carlo loop ─────────────────────────────────────────────────────
   const caseStats: CaseStats[] = [];

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -169,6 +169,11 @@ export async function runAbArms(
       for (let i = 0; i < opts.runs; i++) {
         const target = await runTarget(armCase, { model });
         if (target.errored) {
+          // Surface the failure detail (as the single-arm loop does) so an arm
+          // error is diagnosable, not silently counted as a fail.
+          console.log(
+            `  ERROR (A/B) [${c.tier}] ${c.id} run ${i + 1}/${opts.runs} — ${target.detail}`,
+          );
           runResults.push(false);
           continue;
         }


### PR DESCRIPTION
## Summary

Sub-PR **C-c** of Unit C → integration branch `feat/platform-gaps-2026-agent-eval`. Adds **A/B control-vs-treatment mode** to the runner: `pnpm eval:agents --ab` runs a control and a treatment arm of the same case, reports the success-rate delta with pooled variance, and flags `degraded` when the treatment is meaningfully worse. This makes "is this CLAUDE.md rule load-bearing" a measurement.

- **`lib/eval/ab.ts`** — `abDelta(control, treatment)` → `{ controlMean, treatmentMean, deltaMean (treatment − control), deltaStddev (pooled), degraded }`. `degraded` trips only when `deltaMean < -0.05` (an improvement, or sub-noise jitter, is never flagged). Pure (no clock/IO/randomness).
- **Schema extension** (`evals/agents/schema.ts`) — optional `control`/`treatment` systemText variants + an `AbCase<T>` generic + `selectAbCases(cases)` (returns only cases declaring **both** arms). Backward-compatible: the existing 4 corpus cases parse unchanged.
- **Load-bearing-rule case** (`evals/agents/ab-rule-loadbearing/`) — `treatment.systemText` is the platform prompt with the broad-`git add` ban clause **pruned**; the code grader is arm-invariant, so the delta isolates exactly that clause's contribution.
- **`--ab` runner wiring** (`scripts/agent-eval.ts`) — `runAbArms` runs both arms through the same `runTarget`/`gradeRun` seam → `abDelta`; the optional `ab` block is folded into the aggregate (a non-`--ab` run is **byte-identical** to before — key omitted when absent); cost pre-flight passes `doubled: true` so the effective cap is `2 × MAX_JOB_COST_USD`. `buildAggregate` stays pure.

## Type of change

- [x] `feat` — eval-harness A/B mode (ships nothing to the app)

## Test plan

- [x] `pnpm test --run lib/eval evals/agents __tests__/agent-eval-*` — **86 tests pass** (full suite 973 pass)
- [x] `pnpm typecheck` clean · `biome check` clean (1 pre-existing unrelated fixture warning)
- [x] C-c.3 acceptance (SDK mocked, no Gateway call): a weakened pruned-rule treatment yields a **non-zero negative `deltaMean` + `degraded:true`**; the doubled-cost cap accepts a 1.5× projection only with `doubled:true` and rejects an over-2× projection
- [x] 5-agent battery clean — code-reviewer **CLEAN** (abDelta math, backward-compatible schema, doubled cap only in `--ab`, non-AB byte-identical, buildAggregate pure), security **SAFE**, perf/deps/a11y zero

## Visual changes

None — dev/CI tooling only.

## Checklist

- [x] Bundle impact — none (nothing in `app/` imports the new modules)
- [x] A11y impact — none
- [x] ADR — deferred to C-d per the plan (the unit ADR lands with the CI sub-PR)

## Notes

- **Reviewed incrementally** as a sub-PR into the integration branch; the `feat/platform-gaps-2026-agent-eval` → `main` PR follows after C-d (rebased on main then to pick up the deps fixes).
- **Deviation (mechanical):** the plan's C-c literal commit subjects led with "A/B" (start-case), rejected by commitlint's `subject-case`; prepended "add" — the only subject tweak.
- The A/B aggregate carries only success-rate metrics (`deltaMean`/`stddev`/`degraded`), no prompt text or secrets.
