### PR TITLE
ci(perf): post LHCI Lighthouse status via the built-in GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,12 @@ jobs:
       # status-post error). For the richer per-category checks, swap to the LHCI
       # GitHub App's LHCI_GITHUB_APP_TOKEN secret instead.
       LHCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # On pull_request the runner checks out the ephemeral MERGE commit, so LHCI
+      # would post its lhci/url/* statuses there — invisible on the PR. Pin the
+      # build's current hash to the PR HEAD so the statuses (and their report
+      # links) land on the PR commit; on push events this falls back to the
+      # pushed SHA, which already matches the checked-out HEAD.
+      LHCI_BUILD_CONTEXT__CURRENT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # LHCI posts a "Lighthouse CI" commit status linking to the report it
+      # uploads to temporary-public-storage. The basic-token path (not the LHCI
+      # GitHub App) sets a commit status directly via the GitHub API, which needs
+      # statuses: write. The budgets themselves are still enforced by the LHCI
+      # assertions regardless of whether the status posts.
+      statuses: write
     timeout-minutes: 20
     concurrency:
       group: perf-${{ github.ref }}
@@ -358,6 +364,12 @@ jobs:
     needs: [build, detect-changes]
     env:
       LHCI_BUILD_CONTEXT__EXTERNAL_BUILD_URL: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}
+      # The built-in Actions token (no extra secret). LHCI uses LHCI_GITHUB_TOKEN
+      # for the basic GitHub-status path; on fork PRs this token is read-only so
+      # LHCI just warns and skips the status (it never fails the build on a
+      # status-post error). For the richer per-category checks, swap to the LHCI
+      # GitHub App's LHCI_GITHUB_APP_TOKEN secret instead.
+      LHCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/__tests__/scripts/lhci-ci-job.test.ts
+++ b/__tests__/scripts/lhci-ci-job.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const ci = readFileSync(`${process.cwd()}/.github/workflows/ci.yml`, 'utf8');
+
+// Slice the `performance:` job block only (up to the next 2-space-indented
+// sibling key), so another job's permissions/env cannot satisfy an assertion.
+const heading = '\n  performance:';
+const start = ci.indexOf(heading);
+const rest = ci.slice(start + heading.length);
+const nextJobRel = rest.search(/\n {2}\S/);
+const job =
+  nextJobRel === -1 ? ci.slice(start) : ci.slice(start, start + heading.length + nextJobRel);
+
+describe('ci.yml performance job — LHCI GitHub status', () => {
+  it('grants statuses: write so LHCI can post the Lighthouse CI commit status', () => {
+    expect(job).toMatch(/statuses:\s*write/);
+  });
+
+  it('passes the built-in token as LHCI_GITHUB_TOKEN (basic-status path, no extra secret)', () => {
+    // The basic-token path, not the LHCI GitHub App: LHCI_GITHUB_TOKEN (not
+    // LHCI_GITHUB_APP_TOKEN) is the var LHCI reads for direct GitHub-status calls.
+    expect(job).toMatch(/LHCI_GITHUB_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN\s*\}\}/);
+  });
+});

--- a/__tests__/scripts/lhci-ci-job.test.ts
+++ b/__tests__/scripts/lhci-ci-job.test.ts
@@ -29,4 +29,13 @@ describe('ci.yml performance job — LHCI GitHub status', () => {
     // LHCI_GITHUB_APP_TOKEN) is the var LHCI reads for direct GitHub-status calls.
     expect(job).toMatch(/LHCI_GITHUB_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN\s*\}\}/);
   });
+
+  it('pins the build hash to the PR HEAD so statuses land on the PR commit, not the merge SHA', () => {
+    // pull_request checks out the merge commit; without this the lhci/url/*
+    // statuses post there and never show on the PR. head.sha on PRs, github.sha
+    // on push (which already matches the checked-out HEAD).
+    expect(job).toMatch(
+      /LHCI_BUILD_CONTEXT__CURRENT_HASH:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\|\|\s*github\.sha\s*\}\}/,
+    );
+  });
 });

--- a/__tests__/scripts/lhci-ci-job.test.ts
+++ b/__tests__/scripts/lhci-ci-job.test.ts
@@ -13,6 +13,13 @@ const job =
   nextJobRel === -1 ? ci.slice(start) : ci.slice(start, start + heading.length + nextJobRel);
 
 describe('ci.yml performance job — LHCI GitHub status', () => {
+  it('defines a performance job', () => {
+    // Guards the slice: if the job is renamed/removed, this fails loudly instead
+    // of the other assertions passing vacuously against an empty/wrong block.
+    expect(ci).toMatch(/^\s{2}performance:/m);
+    expect(job).not.toBe('');
+  });
+
   it('grants statuses: write so LHCI can post the Lighthouse CI commit status', () => {
     expect(job).toMatch(/statuses:\s*write/);
   });


### PR DESCRIPTION
## Summary

Resolves the `⚠️ GitHub token not set` warning from `lhci`/`lhci:mobile` in the `performance` CI job. LHCI was uploading reports to `temporary-public-storage` but never posting a commit status linking to them.

- Grant the `performance` job **`statuses: write`** (the minimal scope — LHCI's basic-token path sets a commit status via `POST /repos/.../statuses/{sha}`).
- Pass the **built-in `GITHUB_TOKEN`** as `LHCI_GITHUB_TOKEN` (the var for the basic-status path — *not* `LHCI_GITHUB_APP_TOKEN`, which is for the LHCI GitHub App and needs a separate installed-app secret). **No new secret.**
- LHCI now posts a "Lighthouse CI" commit status with the report link.

## Type of change

- [x] `ci` — workflow permission + env (no app code, no runtime/bundle change)

## Test plan

- [x] `pnpm test --run __tests__/scripts/lhci-ci-job.test.ts` — invariant test passes (locks `statuses: write` + the `LHCI_GITHUB_TOKEN` env, scoped to the `performance` job block)
- [x] 5-agent battery clean — security-auditor **SAFE** (`statuses: write` is the minimal scope vs `checks: write`/broader; the token is capped by the job's per-job permissions; fork PRs get a read-only token so LHCI warns and skips, never failing the build; no secret echoed), code-reviewer **CLEAN** (correct env var, well-formed YAML), perf/deps/a11y zero
- The authoritative validation is this PR's own `performance` job posting the status.

## Visual changes

None — CI only.

## Checklist

- [x] No new dependency / secret — uses the built-in `GITHUB_TOKEN`
- [x] Least privilege — only `statuses: write` added (job keeps `contents: read`); per-job, isolated from other jobs
- [x] Bundle / A11y impact — none

## Notes

- **Budgets unchanged.** The perf budgets are enforced by the LHCI assertions regardless of whether the status posts; this PR only adds the status/report link, it does not change any threshold.
- **No new privacy surface.** Reports already uploaded to `temporary-public-storage` (the URLs print in the CI log); the site is a public portfolio. The token only makes the (already public) report linkable from the commit.
- **Richer option not adopted:** the LHCI GitHub App (`LHCI_GITHUB_APP_TOKEN`) gives per-category status checks but adds a powerful new secret to manage — skipped for a solo repo.
