### PR TITLE
fix(review): broaden claude-gate SHA regex for the 'HEAD (`sha`)' format

### DIFF
--- a/__tests__/scripts/check-claude-approval.test.ts
+++ b/__tests__/scripts/check-claude-approval.test.ts
@@ -5,7 +5,8 @@
 //
 // Verdict formats are taken from real claude-review overviews observed on this
 // repo's PRs (#152 "(head `sha`)", #153 "Reviewed at HEAD `sha`", #154
-// "Reviewed at head commit `sha`."), so the gate survives the format variance.
+// "Reviewed at head commit `sha`.", #155 "the committed HEAD (`sha`):"), so the
+// gate survives the format variance.
 
 import { describe, expect, it } from 'vitest';
 import {

--- a/__tests__/scripts/check-claude-approval.test.ts
+++ b/__tests__/scripts/check-claude-approval.test.ts
@@ -94,7 +94,19 @@ describe('extractReviewedSha', () => {
     expect(extractReviewedSha(`This PR (head \`${sha}\`) does X.`)).toBe(sha);
   });
 
+  it('extracts from the "committed HEAD (`sha`):" form (separator between head and the backtick)', () => {
+    const sha = '3665027e14b928faa3dad325b202efc24077fc5b';
+    expect(extractReviewedSha(`...confirmed fixed in the committed HEAD (\`${sha}\`):`)).toBe(sha);
+  });
+
   it('returns null when no head SHA is present', () => {
     expect(extractReviewedSha('Approve. No commit reference here.')).toBeNull();
+  });
+
+  it('does not match a backticked SHA quoted far away from the head declaration', () => {
+    // "head" appears, but the only backticked SHA is in unrelated prose well past
+    // the proximity window, so it must NOT be treated as the reviewed head.
+    const body = 'The head of the list is fine; separately, an old run was at `deadbeef1234567`.';
+    expect(extractReviewedSha(body)).toBeNull();
   });
 });

--- a/scripts/check-claude-approval.ts
+++ b/scripts/check-claude-approval.ts
@@ -32,11 +32,14 @@ export function parseClaudeVerdict(body: string): ClaudeVerdict {
   return 'none';
 }
 
-// Extract the head SHA the review states it ran against. The overview format has
-// varied ("Reviewed at head commit `sha`.", "Reviewed at HEAD `sha`.",
-// "(head `sha`)"), so match a backticked 7-40 hex token right after "head".
+// Extract the head SHA the review states it ran against. The overview phrasing
+// varies a lot ("Reviewed at head commit `sha`.", "Reviewed at HEAD `sha`.",
+// "(head `sha`)", "the committed HEAD (`sha`):"), so match the first backticked
+// 7-40 hex token that appears within a short window after the word "head" — the
+// window absorbs separators like " commit ", " (", ": " without matching an
+// unrelated SHA quoted far away from the head declaration.
 export function extractReviewedSha(body: string): string | null {
-  const sha = body.match(/\bhead\b(?:\s+commit)?\s*`([0-9a-f]{7,40})`/i)?.[1];
+  const sha = body.match(/\bhead\b[^`\n]{0,24}`([0-9a-f]{7,40})`/i)?.[1];
   return sha ? sha.toLowerCase() : null;
 }
 


### PR DESCRIPTION
## Summary

- Fast-follow to #155: the just-merged claude-review gate (`scripts/check-claude-approval.ts`) had a too-narrow SHA-extraction regex. It could not parse claude's `the committed HEAD (\`sha\`):` Approve phrasing (the ` (` separator), so the gate's fail-closed-on-null-SHA logic blocked a legitimate Approve. The gate correctly refused a review it could not verify — the parser was just too narrow for that 4th observed format.
- **Fix:** widen `extractReviewedSha` to match the first backticked 7-40 hex token within a 24-char window after the word "head" (`/\bhead\b[^\`\n]{0,24}\`([0-9a-f]{7,40})\`/i`), absorbing ` commit `, ` (`, `: ` separators. The `[^\`\n]` class prevents crossing a backtick/newline so it cannot grab a SHA from a different sentence or code block.
- Discovered by the gate's own new fail-closed behavior (introduced in #155) blocking #155's own Approve. Without this, the live merge gate blocks any PR whose claude Approve uses the `HEAD (\`sha\`)` format.

## Type of change

- [x] `fix` — bug fix (the just-shipped merge gate)
- [ ] `feat` · [ ] `refactor` · [ ] `perf` · [ ] `chore`/`ci`/`docs`

## Test plan

- [x] `pnpm test --run __tests__/scripts/check-claude-approval.test.ts` — 18 pass, incl. 2 new: the `committed HEAD (\`sha\`):` form parses; a SHA >24 chars from "head" returns null (window not leaking)
- [x] Live-verified: `extractReviewedSha("...committed HEAD (\`3665027...\`):")` → returns the SHA (main's version returns null)
- [x] `pnpm tsc --noEmit` clean; the gate stays fail-closed (null SHA still fails in `evaluateGate`)

## Visual changes

- No UI changes. One regex + 2 tests in a CI-gate script. Ships zero bytes to the client.

## Checklist

- [x] No hardcoded hex / magic numbers — N/A
- [x] No `use client` added — N/A
- [x] Bundle size impact assessed — zero
- [x] A11y impact considered — zero surface
- [x] ADR added if architecture changed — N/A (bugfix to the #155 gate; no new decision)

5-agent battery: all clean (code-reviewer: 18/18, all 4 formats parse, no ReDoS, fail-closed preserved; security: SAFE, linear bounded regex). Net: 2 files, +19/-4.
