### PR TITLE
docs(handbook): spec clarify convention + ADR (Unit F)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2,6 +2,10 @@
 
 ADR-lite running log. One bullet per decision · date · reversibility note.
 
+## 2026-06-20 - Spec `clarify` convention
+
+- **2026-06-20** · **`## Clarifications resolved` spec-template convention (handbook-routed, smallest platform-gaps unit).** Every spec now carries a `## Clarifications resolved` section listing the open design questions the brainstorming interview closed and their resolutions, in the form `<question> -> <resolution>`. Documented in `docs/handbook/knowledge-architecture.md`'s spec→plan pipeline section; several specs in this program already use the shape implicitly, so the convention names existing practice rather than adding ceremony. The failure mode it addresses: a spec that omits what the interview decided forces a reader (or the architect gate) to replay the interview to recover intent. **Deliberately scoped down from the rev.1 design:** the proposed `tasks` artifact was DROPPED because the plans in the plans directory already ARE stable-ID checkbox task lists mapping one-to-one to commits, so a separate artifact would duplicate and fragment the working single-plan pattern; and the convention was routed to the handbook rather than a `.claude/` skill or rule (a skill fires on action triggers, a rule needs a file-scope trigger, and this is a passive reference convention), adding zero `.claude/` surface and zero CLAUDE.md prose. _Reversible: revert the single `docs/handbook/knowledge-architecture.md` edit; no code, no production impact, no `.claude/` change._
+
 ## 2026-06-20 — claude-review is the sole AI PR reviewer (Copilot dropped)
 
 - **2026-06-20** — **GitHub Copilot review dropped; `/claude-review` (claude[bot]) is now the sole AI reviewer.** Copilot's bot errored GitHub-side across an entire working session while claude-review carried the real review load, so the user made claude-review the standing reviewer. The convergence loop re-requests only `/claude-review`; nothing requests `copilot-pull-request-reviewer` anymore. _Reversible: re-add a Copilot request step + restore the copilot-gate._

--- a/docs/handbook/knowledge-architecture.md
+++ b/docs/handbook/knowledge-architecture.md
@@ -80,6 +80,28 @@ flowchart LR
 
 A spec is the approved "what and why" with explicit gaps to close. A plan is its 1:1 paired "how", decomposed into tasks and (for large work) sharded into sub-PR plans and workstreams. The architect gate sits between them, mechanically.
 
+### The `clarify` convention (spec template)
+
+Every spec carries a `## Clarifications resolved` section: the design questions the
+brainstorming interview opened and the resolution each one closed with. This names a
+shape several specs already use implicitly. It makes the spec self-contained (a reader
+sees what was decided and why, without replaying the interview) and gives the
+architect gate an explicit list to check the plan against. The section is a short
+list, one line per question, in the form `<open question> -> <resolution>`:
+
+```markdown
+## Clarifications resolved
+
+- Should the `tasks` artifact be a separate file? -> No; plans already carry
+  stable-ID checkbox tasks, so a separate artifact would duplicate them.
+- Where does the convention live? -> The handbook, not a skill or rule (it is a
+  passive reference convention, not an action trigger).
+```
+
+There is no separate `tasks` artifact: the plans in the plans directory already ARE
+discrete, stable-ID checkbox task lists that map one-to-one to commits, so the "how"
+decomposition the convention would otherwise add already exists in every plan.
+
 ## The memory system
 
 Two complementary mechanisms carry knowledge across the fresh-context boundary of each session:


### PR DESCRIPTION
## Summary

- Unit F (smallest platform-gaps unit): formalizes the `## Clarifications resolved` spec-template convention, documented in the handbook's spec→plan pipeline section + recorded as an ADR.
- **Convention:** every spec carries a `## Clarifications resolved` section listing the design questions the brainstorming interview closed and their resolutions (`<question> -> <resolution>`). It names a shape several specs already use implicitly, makes specs self-contained, and gives the architect gate an explicit list to check the plan against.
- **Deliberately scoped down from rev.1:** the proposed separate `tasks` artifact was DROPPED (plans already ARE stable-ID checkbox task lists mapping 1:1 to commits), and the convention is handbook-routed rather than a `.claude/` skill/rule (it is a passive reference convention, not an action trigger) — zero `.claude/` surface, zero CLAUDE.md prose.

## Type of change

- [ ] `feat` · [ ] `fix` · [ ] `refactor` · [ ] `perf`
- [x] `chore` / `ci` / `docs` — documentation convention + ADR

## Test plan

- [x] `pnpm check:doc-drift` exits 0 (✓ 82 paths checked, 0 stale) — the only gate touching docs; no files added/moved
- [x] Self-review checklist (from the plan) all pass: convention placed inside `## The spec -> plan pipeline` before `## The memory system`; the `## Clarifications resolved` example is inside a fenced code block; no hard-coded counts; no em dash in added prose; ADR newest-first with a reversibility note; zero files created, zero `.claude/`/CLAUDE.md touched
- New behaviour covered by tests: N/A — a documentation convention, validated by application (several specs already use the shape)

## Visual changes

- No UI changes. Two markdown docs (handbook + DECISIONS.md). Ships zero bytes to the client.

## Checklist

- [x] No hardcoded hex / magic numbers — N/A
- [x] No `use client` added — N/A
- [x] Bundle size impact assessed — zero
- [x] A11y impact considered — zero surface
- [x] ADR added to `DECISIONS.md` — yes (this PR's second deliverable)

5-agent battery: all clean (code-reviewer verified all 8 plan checklist items; security/perf/deps/a11y zero surface). Net: 2 files, +26.
