### PR TITLE
test(agent-eval): corpus cases for consumer-scan + claude-review rules

### DIFF
--- a/__tests__/agent-eval-ab.test.ts
+++ b/__tests__/agent-eval-ab.test.ts
@@ -48,9 +48,10 @@ describe('agent-eval --ab (SDK mocked, no real Gateway call)', () => {
     });
 
     // Scope to the git-add A/B fixture this mock is written for: the mock routes by
-    // the git-add rule text and emits git-add responses, so it only grades that case.
-    // Other A/B cases in the corpus (e.g. ab-consumer-scan-ci-config) have different
-    // graders and must not be driven by this git-add mock.
+    // the git-add rule text and emits `git add ...` responses. Other A/B cases (e.g.
+    // ab-consumer-scan-ci-config) also use grader 'code' but a DIFFERENT assert
+    // predicate, which the git-add responses do not satisfy, so this mock must not
+    // drive them.
     const abCases = selectAbCases(await loadCases()).filter((c) => c.id === 'ab-rule-loadbearing');
     expect(abCases.length).toBe(1);
 

--- a/__tests__/agent-eval-ab.test.ts
+++ b/__tests__/agent-eval-ab.test.ts
@@ -47,8 +47,12 @@ describe('agent-eval --ab (SDK mocked, no real Gateway call)', () => {
       return reply(i === 0 ? 'git add lib/eval/ab.ts' : 'git add -A');
     });
 
-    const abCases = selectAbCases(await loadCases());
-    expect(abCases.length).toBeGreaterThan(0);
+    // Scope to the git-add A/B fixture this mock is written for: the mock routes by
+    // the git-add rule text and emits git-add responses, so it only grades that case.
+    // Other A/B cases in the corpus (e.g. ab-consumer-scan-ci-config) have different
+    // graders and must not be driven by this git-add mock.
+    const abCases = selectAbCases(await loadCases()).filter((c) => c.id === 'ab-rule-loadbearing');
+    expect(abCases.length).toBe(1);
 
     const { control, treatment, ab } = await runAbArms(abCases, {
       runs: 5,

--- a/evals/agents/__tests__/corpus.test.ts
+++ b/evals/agents/__tests__/corpus.test.ts
@@ -1,15 +1,20 @@
 // evals/agents/__tests__/corpus.test.ts
-// Structural test for the seeded agent-eval corpus. Imports the three single-arm
-// seed CASE.ts modules directly (the loader is C-a.9; the A/B-variant
-// ab-rule-loadbearing case added in C-c is covered by ab-variant.test.ts) and
-// asserts the corpus invariants the Monte-Carlo runner depends on: unique ids;
-// at least one code grader; at least
-// one knownHard case (anti-saturation — the eval must not saturate at 100% and
-// stop discriminating); and both tiers represented (mechanical → haiku,
-// judgment → sonnet model assignment).
+// Structural test for the seeded agent-eval corpus. The `cases` array uses the
+// three single-arm seed CASE.ts modules to assert the corpus invariants the
+// Monte-Carlo runner depends on: unique ids; at least one code grader; at least
+// one knownHard case (anti-saturation, the eval must not saturate at 100% and
+// stop discriminating); and both tiers represented (mechanical -> haiku,
+// judgment -> sonnet model assignment).
+//
+// It also pins the BEHAVIORAL BOUNDARY of each non-trivial code-grader assert with
+// known PASS/FAIL inputs (the git-add seed, plus the claude-review-request and
+// ab-consumer-scan-ci-config asserts added 2026-06-20), so a regex regression is
+// caught here rather than only surfacing as a corpus-wide eval drift.
 
 import { describe, expect, it } from 'vitest';
+import abConsumerScan from '@/evals/agents/ab-consumer-scan-ci-config/CASE';
 import architectGateRespect from '@/evals/agents/architect-gate-respect/CASE';
+import claudeReviewRequest from '@/evals/agents/claude-review-request/CASE';
 import gitAddScoping from '@/evals/agents/git-add-scoping/CASE';
 import rulePruningKnownHard from '@/evals/agents/rule-pruning-knownhard/CASE';
 import { AgentEvalCaseSchema } from '@/evals/agents/schema';
@@ -54,6 +59,37 @@ describe('evals/agents seeded corpus', () => {
       expect(assertFn('Run git add . to stage everything.')).toBe(false);
       expect(assertFn('git add -A then commit')).toBe(false);
       expect(assertFn('git add --all')).toBe(false);
+    }
+  });
+
+  it('the claude-review-request assert passes /claude-review (incl. "not Copilot" prose) and rejects the Copilot add-reviewer command', () => {
+    expect(claudeReviewRequest.grader).toBe('code');
+    const a = claudeReviewRequest.assert;
+    expect(a).toBeTypeOf('function');
+    if (a) {
+      expect(a('gh pr comment 42 --body /claude-review')).toBe(true);
+      // The boundary the code comment documents: "not Copilot" prose must still PASS.
+      expect(a('Run /claude-review. Do not request Copilot.')).toBe(true);
+      // The banned form is the request COMMAND / bot handle.
+      expect(a('gh pr edit 42 --add-reviewer copilot-pull-request-reviewer')).toBe(false);
+      // No claude-review requested at all → fail.
+      expect(a('I would wait for the automated review.')).toBe(false);
+    }
+  });
+
+  it('the consumer-scan assert requires scanning the CI/config surface, not just code callers', () => {
+    expect(abConsumerScan.grader).toBe('code');
+    const a = abConsumerScan.assert;
+    expect(a).toBeTypeOf('function');
+    if (a) {
+      // Control-style answer: scans the workflow path-filter surface → pass.
+      expect(
+        a('grep .github/workflows for the detect-changes path-filter referencing the old path'),
+      ).toBe(true);
+      // Treatment-style answer: code callers only, no CI/config surface → fail.
+      expect(
+        a('grep -r judge --include=*.ts --include=*.tsx for code callers and update each import'),
+      ).toBe(false);
     }
   });
 });

--- a/evals/agents/__tests__/corpus.test.ts
+++ b/evals/agents/__tests__/corpus.test.ts
@@ -1,6 +1,8 @@
 // evals/agents/__tests__/corpus.test.ts
-// Structural test for the seeded agent-eval corpus. The `cases` array uses the
-// three single-arm seed CASE.ts modules to assert the corpus invariants the
+// Structural test for the agent-eval corpus. The `cases` array holds the single-arm
+// cases (the original seeds plus claude-review-request); A/B cases (ab-rule-loadbearing,
+// ab-consumer-scan-ci-config) are excluded by convention and exercised by
+// ab-variant.test.ts. It asserts the corpus invariants the
 // Monte-Carlo runner depends on: unique ids; at least one code grader; at least
 // one knownHard case (anti-saturation, the eval must not saturate at 100% and
 // stop discriminating); and both tiers represented (mechanical -> haiku,
@@ -19,7 +21,7 @@ import gitAddScoping from '@/evals/agents/git-add-scoping/CASE';
 import rulePruningKnownHard from '@/evals/agents/rule-pruning-knownhard/CASE';
 import { AgentEvalCaseSchema } from '@/evals/agents/schema';
 
-const cases = [gitAddScoping, architectGateRespect, rulePruningKnownHard];
+const cases = [gitAddScoping, architectGateRespect, rulePruningKnownHard, claudeReviewRequest];
 
 describe('evals/agents seeded corpus', () => {
   it('every case re-parses the schema', () => {

--- a/evals/agents/__tests__/corpus.test.ts
+++ b/evals/agents/__tests__/corpus.test.ts
@@ -1,8 +1,9 @@
 // evals/agents/__tests__/corpus.test.ts
 // Structural test for the agent-eval corpus. The `cases` array holds the single-arm
 // cases (the original seeds plus claude-review-request); A/B cases (ab-rule-loadbearing,
-// ab-consumer-scan-ci-config) are excluded by convention and exercised by
-// ab-variant.test.ts. It asserts the corpus invariants the
+// ab-consumer-scan-ci-config) are excluded by convention: structurally validated by
+// load.test.ts (which schema-parses every discovered case), with their assert
+// boundaries pinned by the PASS/FAIL boundary tests below. It asserts the corpus invariants the
 // Monte-Carlo runner depends on: unique ids; at least one code grader; at least
 // one knownHard case (anti-saturation, the eval must not saturate at 100% and
 // stop discriminating); and both tiers represented (mechanical -> haiku,

--- a/evals/agents/ab-consumer-scan-ci-config/CASE.ts
+++ b/evals/agents/ab-consumer-scan-ci-config/CASE.ts
@@ -1,0 +1,71 @@
+// evals/agents/ab-consumer-scan-ci-config/CASE.ts
+//
+// A/B case, CODE grader. Target: the CLAUDE.md consumer-scan rule (added 2026-06-20,
+// PR #152) requiring a file move OR extraction to scan BOTH the code callers AND the
+// gate/CI/config surface (`.github/workflows` path-filters, `.husky`, scripts,
+// allowlists) for references to the moved path. The control arm carries the full
+// rule; the treatment arm prunes the "(2) CI/config surface" clause, leaving only
+// the code-caller scan. The --ab runner measures the success-rate delta: if the
+// CI/config clause is load-bearing, the treatment stops emitting the
+// scan-the-workflow-path-filters step that the control produces, yielding a negative
+// delta. This is the exact failure class that leaked the `lib/eval/` ai-filter gap
+// (a judge extraction left ci.yml's detect-changes pathspec pointing at the old
+// home, so the calibration gate silently skipped).
+//
+// Judgment tier: the model must reason about WHERE a moved symbol is still referenced,
+// not emit a fixed string. The base `target.systemText` mirrors the control so a
+// single-arm (non --ab) run still exercises the full rule.
+
+import { type CodeAssertion, validateAgentEvalCase } from '@/evals/agents/schema';
+
+// PASS iff the plan references scanning the CI/config/gate surface (the distinctive
+// thing the rule adds beyond a plain code-caller grep): GitHub workflows, the
+// detect-changes path-filter, husky hooks, or a pathspec/allowlist. A code-callers-only
+// answer (the treatment's expected behavior) does NOT mention these and FAILS.
+const assert: CodeAssertion = (output: string): boolean =>
+  /\.github\/workflows|detect-changes|path-?filter|\bci\.yml\b|\.husky|pathspec|allowlist|workflow file/i.test(
+    output,
+  );
+
+// Control: the full consumer-scan rule, including the CI/config surface clause.
+const CONTROL_SYSTEM_TEXT =
+  'Before writing plan tasks for any file move OR extraction (relocating code or a symbol ' +
+  'into a new module or path), grep for every reference to the old path or symbol across TWO ' +
+  'surfaces: (1) code callers (grep the .ts/.tsx imports); AND (2) the gate/CI/config surface ' +
+  'that hard-codes paths: .github/workflows path-filters (detect-changes especially), .husky ' +
+  'hooks, scripts, and any allowlist or pathspec. A CI path-filter left pointing at the old ' +
+  'location fails open silently (the gate evaluates to unchanged, skips, and a regression ships ' +
+  'unguarded). Include a path-update task for every match including config and test files.';
+
+// Treatment: the SAME rule with the "(2) CI/config surface" clause PRUNED. It still
+// asks to scan code callers, but no longer names the workflow/path-filter/config
+// surface (the variable under test for whether that clause is load-bearing).
+const TREATMENT_SYSTEM_TEXT =
+  'Before writing plan tasks for any file move OR extraction, grep for every reference to the ' +
+  'old path or symbol among the code callers (grep the .ts/.tsx imports). Include a path-update ' +
+  'task for every match including test files.';
+
+export default validateAgentEvalCase(
+  {
+    id: 'ab-consumer-scan-ci-config',
+    prompt:
+      'You are about to extract the judge() function and the JUDGE_SYSTEM constant out of ' +
+      'scripts/ask-eval.ts into a new module lib/eval/judge.ts, and import them back. Before ' +
+      'you write the implementation plan, list the consumer-scan steps you would run to make ' +
+      'sure nothing is left pointing at the old location after the move.',
+    target: {
+      name: 'CLAUDE.md:consumer-scan-ci-config',
+      systemText: CONTROL_SYSTEM_TEXT,
+    },
+    tier: 'judgment',
+    grader: 'code',
+    expect:
+      'The consumer-scan steps include scanning the CI/config surface (.github/workflows ' +
+      'path-filters such as detect-changes, gates, allowlists/pathspecs) for the old path, not ' +
+      'just code callers.',
+    knownHard: false,
+    control: { systemText: CONTROL_SYSTEM_TEXT },
+    treatment: { systemText: TREATMENT_SYSTEM_TEXT },
+  },
+  assert,
+);

--- a/evals/agents/ab-consumer-scan-ci-config/PROMPT.md
+++ b/evals/agents/ab-consumer-scan-ci-config/PROMPT.md
@@ -1,0 +1,10 @@
+# Task: consumer-scan before an extraction
+
+You are about to extract the `judge()` function and the `JUDGE_SYSTEM` constant
+out of `scripts/ask-eval.ts` into a new module `lib/eval/judge.ts`, and import
+them back into `scripts/ask-eval.ts`.
+
+Before you write the implementation plan, list the consumer-scan steps you would
+run to make sure nothing is left pointing at the old location after the move.
+
+Respond with the scan steps.

--- a/evals/agents/claude-review-request/CASE.ts
+++ b/evals/agents/claude-review-request/CASE.ts
@@ -1,0 +1,47 @@
+// evals/agents/claude-review-request/CASE.ts
+//
+// Deterministic case, CODE grader. Target: the CLAUDE.md review-flow rule (set
+// 2026-06-20, PR #155) that a PR review is requested via /claude-review, with
+// GitHub Copilot dropped as the AI reviewer. PASS iff the output requests the
+// claude-review and does NOT request Copilot as a reviewer (the old `gh pr edit
+// --add-reviewer copilot-pull-request-reviewer` form). Mechanical tier: the
+// expected action is a near-fixed command, so haiku should produce it given the rule.
+//
+// Note the assert bans the copilot-REQUEST forms, not any mention of "Copilot":
+// a correct answer may say "claude-review, not Copilot" and must still pass.
+
+import { type CodeAssertion, validateAgentEvalCase } from '@/evals/agents/schema';
+
+const assert: CodeAssertion = (output: string): boolean => {
+  const requestsClaudeReview = /\/?claude-review/i.test(output);
+  // Ban only the concrete Copilot-REQUEST forms (the command + the bot handle), not
+  // any mention of "Copilot". A correct answer may say "claude-review, not Copilot",
+  // and matching loose prose like "request Copilot" would mis-flag "do not request
+  // Copilot". The prompt asks for the exact command/action, so the command form is
+  // the discriminating signal.
+  const requestsCopilot = /add-reviewer\s+copilot|copilot-pull-request-reviewer/i.test(output);
+  return requestsClaudeReview && !requestsCopilot;
+};
+
+export default validateAgentEvalCase(
+  {
+    id: 'claude-review-request',
+    prompt:
+      'You have opened a pull request and want the AI reviewer to review it. State the exact ' +
+      'command or action you would take to request the review.',
+    target: {
+      name: 'CLAUDE.md:claude-review',
+      systemText:
+        'Request a PR review by commenting `/claude-review` on the PR (e.g. ' +
+        '`gh pr comment <pr> --body /claude-review`). claude-review is the AI reviewer; ' +
+        'GitHub Copilot was dropped, so do not request it as a reviewer.',
+    },
+    tier: 'mechanical',
+    grader: 'code',
+    expect:
+      'The action requests `/claude-review` (claude-review) and does NOT request Copilot as a ' +
+      'reviewer (no `gh pr edit --add-reviewer copilot`).',
+    knownHard: false,
+  },
+  assert,
+);

--- a/evals/agents/claude-review-request/PROMPT.md
+++ b/evals/agents/claude-review-request/PROMPT.md
@@ -1,0 +1,7 @@
+# Task: request the AI review
+
+You have opened a pull request and want the AI reviewer to review it.
+
+State the exact command or action you would take to request the review.
+
+Respond with the command you would run.


### PR DESCRIPTION
## Summary

- Extends Unit C's agent-eval corpus with cases for rules shipped this session, so the weekly self-eval actually measures whether those rules are load-bearing.
- **`ab-consumer-scan-ci-config`** (A/B, judgment, code grader): the #152 consumer-scan rule. Control = full rule (scan code callers AND the CI/config surface: `.github/workflows` path-filters, `.husky`, scripts, pathspecs); treatment = same rule with the CI/config clause pruned. The `--ab` runner measures the success-rate delta, so a load-bearing clause shows up as the treatment dropping the workflow-path-filter scan the control keeps. This is the exact class that leaked the `lib/eval/` ai-filter gap.
- **`claude-review-request`** (mechanical, code grader): the #155 review-flow rule. PASS iff the action requests `/claude-review` and not the Copilot add-reviewer command (the ban targets the command form, so "not Copilot" prose still passes).
- Also fixes a brittle pre-existing test: `agent-eval-ab.test.ts` ran `--ab` over ALL A/B cases with a git-add-specific mock; scoped it to its fixture case so new A/B cases don't couple to that mock.

## Type of change

- [x] `test` — agent-eval corpus + a test robustness fix
- [ ] `feat` · [ ] `fix` · [ ] `perf` · [ ] `chore`/`ci`/`docs`

## Test plan

- [x] `pnpm test --run` green (145 files, 1011 passed) — incl. 27 evals/agents tests (the loader picks up both new cases) and the now-scoped `--ab` test
- [x] Assert discrimination verified manually for both code graders: consumer-scan control (mentions `.github/workflows`/`detect-changes`) PASS vs treatment (code-callers-only) FAIL; claude-review-request `/claude-review` + "not Copilot" prose PASS vs the Copilot add-reviewer command FAIL
- [x] `pnpm tsc --noEmit` clean; biome clean; em-dash-free authored comments
- [x] **End-to-end proof:** `agent-eval.yml` dispatched on this branch (runs the 6-case corpus through the model with the Gateway key) — linked in a comment

## Visual changes

- No UI changes. Agent-eval corpus data (TypeScript + markdown) + a test. Ships zero bytes to the client.

## Checklist

- [x] No hardcoded hex / magic numbers — N/A
- [x] No `use client` added — N/A
- [x] Bundle size impact assessed — zero (eval-harness data only)
- [x] A11y impact considered — zero surface
- [x] ADR added to `DECISIONS.md` — N/A (corpus extension of an existing harness, no new architectural decision)

5-agent battery: all clean across the cases, the em-dash fix, and the test scoping fix (code-reviewer confirmed the assert discrimination, the A/B isolates the pruned clause, and the test scoping is correct).
