### PR TITLE
fix(scripts): normalize entry-module guards to pathToFileURL().href

### DIFF
--- a/scripts/check-branch-protection.ts
+++ b/scripts/check-branch-protection.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
 import { execFile } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { sanitizeSecrets } from './lib/sanitize-secrets';
 
@@ -97,5 +98,6 @@ async function main() {
   }
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+const isMain =
+  typeof process.argv[1] === 'string' && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) void main();

--- a/scripts/check-claude-approval.ts
+++ b/scripts/check-claude-approval.ts
@@ -15,6 +15,7 @@
 // running this check. Only AI agents are bound by the rule.
 
 import { execFile } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
 const execFileP = promisify(execFile);
@@ -136,7 +137,10 @@ async function resolvePrNumber(passed: string | undefined): Promise<number> {
 }
 
 // Only run the gate when invoked directly, not when imported by the unit test.
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+if (
+  typeof process.argv[1] === 'string' &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   run().catch((err) => {
     process.stderr.write(`[claude-gate] ${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);

--- a/scripts/check-pr-comments.ts
+++ b/scripts/check-pr-comments.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
 import { execFile } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { sanitizeSecrets } from './lib/sanitize-secrets';
 
@@ -197,5 +198,6 @@ async function main() {
   }
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+const isMain =
+  typeof process.argv[1] === 'string' && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) void main();

--- a/scripts/check-semgrep-fixture.mjs
+++ b/scripts/check-semgrep-fixture.mjs
@@ -47,6 +47,7 @@ import { spawnSync } from 'node:child_process';
 import { cpSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const FIXTURE_DIR = 'tests/fixtures/semgrep';
 const VENDORED_CONFIG = '.semgrep';
@@ -149,4 +150,5 @@ export function run({
 }
 
 // Run only when invoked directly, not when imported by the unit test.
-if (import.meta.url === `file://${process.argv[1]}`) run();
+if (typeof process.argv[1] === 'string' && import.meta.url === pathToFileURL(process.argv[1]).href)
+  run();

--- a/scripts/validate-pr-body.ts
+++ b/scripts/validate-pr-body.ts
@@ -13,6 +13,7 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const C = {
   reset: '\x1b[0m',
@@ -152,5 +153,6 @@ function main() {
   }
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+const isMain =
+  typeof process.argv[1] === 'string' && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) main();


### PR DESCRIPTION
## Summary

- Five CLI/CI scripts gated their run-as-main check with a hand-built file URL, `import.meta.url === \`file://\${process.argv[1]}\``. That string comparison breaks when the invoked path contains URL-significant characters (spaces, `#`, non-ASCII) or resolves through a symlink, so the script can silently fail to run as main (a gate that does nothing fails open).
- Normalized all five to `typeof process.argv[1] === 'string' && import.meta.url === pathToFileURL(process.argv[1]).href`, which encodes and canonicalizes the path the same way Node sets `import.meta.url`. This matches the existing in-repo precedent at `scripts/agent-eval.ts:408`.
- Files: `check-branch-protection`, `check-pr-comments`, `check-claude-approval`, `validate-pr-body`, `check-semgrep-fixture` (the last closes the deferred MINOR documented in PR #160's body). The added `typeof` narrowing also makes the comparison well-typed under strict TS and avoids a throw when `argv[1]` is absent.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new functionality
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [ ] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes (1027 tests, lint + type + content + client-naming + harness-size gates green)
- [x] Behavioral smoke: each script run directly still enters `main` — `check-branch-protection` passes (`Branch protection OK`), and the PR-scoped gates (`check-pr-comments`, `check-claude-approval`, `validate-pr-body`) error gracefully with no PR on this branch, proving `main` executed.
- [x] `check-semgrep-fixture.mjs` run as main exits 0 (real semgrep); its 14 unit tests confirm import does NOT trigger main.
- [x] 5-agent review battery clean (security-auditor verified neither the claude-approval nor branch-protection gate can fail-open: the new guard is strictly more precise and `ready-to-merge.ts` invokes each as the entry module).
- Runtime gates (`gates:runtime`) intentionally skipped: this diff ships zero app/UI/CSS/bundle code, so build/LHCI/E2E measure properties it cannot change. CI remains authoritative.

## Visual changes

N/A — no UI changes (scripts-only).

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary)
- [x] No `use client` added without necessity (RSC drift) — no app code touched
- [x] Bundle size impact assessed — none; scripts are not bundled
- [x] A11y impact considered — no a11y surface (Node CLI scripts)
- [x] ADR added to `DECISIONS.md` if this changes architecture — N/A (no architectural change)

### Known issue justification (pr-size)

`pnpm pr-size` reports SPLIT RECOMMENDED, driven **only** by the subsystem-spread metric (5 ≥ red 5). Files (5) and lines (22) are both green. The heuristic counts each `scripts/*.ts` as its own subsystem, but this is a single atomic change: the identical two-line guard normalization applied across five files. Splitting it into five PRs would review the same one-line edit five times and is strictly worse than one cohesive diff. Opened as one PR per the "known issues require written justification" convention.