### PR TITLE
build(deps): bump pinned GitHub Actions to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache TypeScript build info
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: tsconfig.tsbuildinfo
           key: tsbuildinfo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig*.json') }}
@@ -321,7 +321,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Next.js build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('app/**', 'components/**', 'lib/**', 'design-system/**') }}
@@ -354,7 +354,7 @@ jobs:
 
       - name: Attest build provenance
         if: github.ref == 'refs/heads/main'
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: .next/
 
@@ -409,7 +409,7 @@ jobs:
           path: .next/
 
       - name: Cache Playwright browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-chromium-${{ hashFiles('pnpm-lock.yaml') }}
@@ -459,7 +459,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Cache Playwright browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ contains(matrix.project, 'webkit') && 'webkit' || 'chromium' }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -584,7 +584,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Cache Playwright browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-chromium-${{ hashFiles('pnpm-lock.yaml') }}
@@ -661,7 +661,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -728,7 +728,7 @@ jobs:
         # makes "no findings file" a clean skip and keeps the failure signal on
         # the scan step itself.
         if: always() && hashFiles('semgrep.sarif') != ''
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: semgrep.sarif
           category: semgrep

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-      - uses: anthropics/claude-code-action@806af32823ef69c8ef357086c573a902af641307 # v1
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1
         with:
           # Claude Max subscription token. Tag mode posts as claude[bot] using the
           # action's GitHub App token, minted from this.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-      - uses: anthropics/claude-code-action@806af32823ef69c8ef357086c573a902af641307 # v1
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1
         with:
           # Authenticated via Claude Max subscription token (no per-use API billing).
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,13 +35,13 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: javascript-typescript
           config-file: .github/codeql/codeql-config.yml
 
-      - uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -48,7 +48,7 @@ jobs:
         # run), so binding the key to deps would force a needless full run on every
         # Dependabot bump. A cache miss (first run, or 7-day eviction) is a correct
         # full run that re-seeds the cache.
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .stryker-incremental.json
           key: stryker-incremental-${{ github.run_id }}

--- a/__tests__/scripts/mutation-incremental-config.test.ts
+++ b/__tests__/scripts/mutation-incremental-config.test.ts
@@ -24,7 +24,7 @@ describe('stryker incremental config', () => {
 
 describe('mutation.yml caches the incremental file', () => {
   it('has a SHA-pinned actions/cache step (existence guard for the asserts below)', () => {
-    expect(wf).toContain('actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5');
+    expect(wf).toContain('actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0');
   });
 
   it('caches the incremental file with the evolving-cache key pattern', () => {
@@ -37,7 +37,7 @@ describe('mutation.yml caches the incremental file', () => {
   });
 
   it('places the cache step before the mutation run (so the file is restored first)', () => {
-    const cacheIdx = wf.indexOf('actions/cache@27d5ce7f');
+    const cacheIdx = wf.indexOf('actions/cache@55cc8345');
     const runIdx = wf.indexOf('name: Run mutation tests');
     expect(cacheIdx).toBeGreaterThanOrEqual(0);
     expect(runIdx).toBeGreaterThan(cacheIdx);


### PR DESCRIPTION
## Summary

Lands the pinned GitHub Actions updates proactively (dependabot #168 was closed; the earlier #164/#167 attempts never merged, so `main`'s Actions pins were stale). All SHA-pinned to dependabot's verified targets:

- `actions/cache` v5.0.5 → **v6.1.0** (6 sites: ci.yml ×5 + mutation.yml)
- `actions/setup-python` v5.6.0 → **v6.3.0**
- `github/codeql-action` v4.36.2 → **v4.36.3** (init/autobuild/analyze/upload-sarif)
- `actions/attest-build-provenance` v4.1.0 → **v4.1.1**
- `anthropics/claude-code-action` v1 SHA `806af328…` → `6c0083bb…` (claude.yml + claude-review.yml)

Also updates the `mutation-incremental-config` test's pinned `actions/cache` SHA to v6.1.0 so it matches the bumped `mutation.yml` — the step dependabot can't do, which is why its Actions PRs never passed CI unattended.

## Type of change

- [x] `chore` / `ci` / `docs` — CI Actions maintenance
- [ ] `feat` · `fix` · `refactor` · `perf`

## Test plan

- [x] `pnpm typecheck` clean · `pnpm test --run` → **1088 passed, 2 skipped** · `pnpm check` (Biome) clean · `pnpm check:doc-drift` 0 stale · detect-changes path meta-gate OK.
- [x] The two **major** bumps (`cache` v5→v6, `setup-python` v5→v6) were checked against upstream changelogs: cache v6 = ESM/internal only (no `with:` change); setup-python v6's only breaking change is node 24 (satisfied by `ubuntu-latest`). No `with:` block changes needed.
- [ ] **This PR's own CI run is the authoritative validation** that the majors work (cache restore/save + setup-python + semgrep + codeql steps execute).
- [x] 5-agent battery CLEAN (code verified SHA-pins + changelog compat; security verified pins intact, correct orgs, no new secrets/permissions).

## Visual changes

None — CI workflow YAML + one test only.

## Checklist

- [x] No hardcoded hex / magic numbers — N/A
- [x] No `use client` — N/A
- [x] Bundle size — N/A (CI only)
- [x] A11y — N/A
- [x] ADR — N/A (routine CI maintenance, no architecture change)

## Notes

- Supersedes the closed dependabot #168 (its bumps, now current). SHA-authenticity rests on the #168 dependabot provenance + intact SHA-pin format.
