### PR TITLE
fix(scripts): branch-protection gate asserts required status checks actually apply

### DIFF
--- a/__tests__/scripts/check-branch-protection.test.ts
+++ b/__tests__/scripts/check-branch-protection.test.ts
@@ -9,8 +9,11 @@ function mockGh(payload: unknown, opts: { reject?: Error } = {}) {
 }
 
 describe('evaluateBranchProtection', () => {
-  it('passes when required_conversation_resolution.enabled is true', async () => {
-    const ghExec = mockGh({ required_conversation_resolution: { enabled: true } });
+  it('passes when conversation resolution is on and classic protection requires checks', async () => {
+    const ghExec = mockGh({
+      required_conversation_resolution: { enabled: true },
+      required_status_checks: { contexts: ['typecheck'] },
+    });
     const r = await evaluateBranchProtection({
       owner: 'erikunha',
       repo: 'portfolio',
@@ -66,5 +69,153 @@ describe('evaluateBranchProtection', () => {
     });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('gh_auth_missing');
+  });
+});
+
+function routingGh(routes: {
+  protection?: unknown;
+  rules?: unknown;
+  rulesReject?: Error;
+  rulesRaw?: string;
+}) {
+  return vi.fn(async (args: string[]) => {
+    const path = args[1] ?? '';
+    if (path.includes('/rules/branches/')) {
+      if (routes.rulesReject) throw routes.rulesReject;
+      if (routes.rulesRaw !== undefined) return routes.rulesRaw;
+      return JSON.stringify(routes.rules ?? []);
+    }
+    return JSON.stringify(routes.protection ?? {});
+  });
+}
+
+const CONVO_ON = { required_conversation_resolution: { enabled: true } };
+
+describe('evaluateBranchProtection — required status checks enforcement', () => {
+  it('fails with "required_status_checks_unenforced" when classic has none and no ruleset rule applies (the inert-ruleset incident)', async () => {
+    const ghExec = routingGh({ protection: CONVO_ON, rules: [] });
+    const r = await evaluateBranchProtection({
+      owner: 'erikunha',
+      repo: 'portfolio',
+      branch: 'main',
+      ghExec,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('required_status_checks_unenforced');
+      expect(r.message).toContain('required_status_checks');
+    }
+  });
+
+  it('passes when an applied ruleset rule requires status checks', async () => {
+    const ghExec = routingGh({
+      protection: CONVO_ON,
+      rules: [
+        {
+          type: 'required_status_checks',
+          parameters: { required_status_checks: [{ context: 'typecheck' }, { context: 'build' }] },
+        },
+      ],
+    });
+    const r = await evaluateBranchProtection({
+      owner: 'erikunha',
+      repo: 'portfolio',
+      branch: 'main',
+      ghExec,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('passes via classic protection contexts without consulting the rules endpoint', async () => {
+    const ghExec = routingGh({
+      protection: {
+        ...CONVO_ON,
+        required_status_checks: { contexts: ['typecheck', 'build'], checks: [] },
+      },
+      rulesReject: new Error('should not be called'),
+    });
+    const r = await evaluateBranchProtection({
+      owner: 'erikunha',
+      repo: 'portfolio',
+      branch: 'main',
+      ghExec,
+    });
+    expect(r.ok).toBe(true);
+    expect(ghExec).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes via classic protection checks[] shape when contexts is absent', async () => {
+    const ghExec = routingGh({
+      protection: {
+        ...CONVO_ON,
+        required_status_checks: { checks: [{ context: 'typecheck' }] },
+      },
+    });
+    const r = await evaluateBranchProtection({
+      owner: 'erikunha',
+      repo: 'portfolio',
+      branch: 'main',
+      ghExec,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('fails when the applied rule exists but its required checks list is empty (gutted rule)', async () => {
+    const ghExec = routingGh({
+      protection: CONVO_ON,
+      rules: [{ type: 'required_status_checks', parameters: { required_status_checks: [] } }],
+    });
+    const r = await evaluateBranchProtection({
+      owner: 'erikunha',
+      repo: 'portfolio',
+      branch: 'main',
+      ghExec,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('required_status_checks_unenforced');
+  });
+
+  it('fails closed with "unknown" when the rules query errors and classic has no checks', async () => {
+    const ghExec = routingGh({ protection: CONVO_ON, rulesReject: new Error('HTTP 500') });
+    const r = await evaluateBranchProtection({
+      owner: 'erikunha',
+      repo: 'portfolio',
+      branch: 'main',
+      ghExec,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('unknown');
+  });
+
+  it('fails closed with "unknown" on non-JSON rules output', async () => {
+    const ghExec = routingGh({ protection: CONVO_ON, rulesRaw: 'not json' });
+    const r = await evaluateBranchProtection({
+      owner: 'erikunha',
+      repo: 'portfolio',
+      branch: 'main',
+      ghExec,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('unknown');
+  });
+
+  it('conversation-resolution failure takes priority over status-check evaluation', async () => {
+    const ghExec = routingGh({
+      protection: { required_conversation_resolution: { enabled: false } },
+      rules: [
+        {
+          type: 'required_status_checks',
+          parameters: { required_status_checks: [{ context: 'typecheck' }] },
+        },
+      ],
+    });
+    const r = await evaluateBranchProtection({
+      owner: 'erikunha',
+      repo: 'portfolio',
+      branch: 'main',
+      ghExec,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('conversation_resolution_off');
   });
 });

--- a/scripts/check-branch-protection.ts
+++ b/scripts/check-branch-protection.ts
@@ -10,7 +10,12 @@ export type EvalResult =
   | { ok: true }
   | {
       ok: false;
-      code: 'conversation_resolution_off' | 'branch_unprotected' | 'gh_auth_missing' | 'unknown';
+      code:
+        | 'conversation_resolution_off'
+        | 'required_status_checks_unenforced'
+        | 'branch_unprotected'
+        | 'gh_auth_missing'
+        | 'unknown';
       message: string;
     };
 
@@ -39,7 +44,10 @@ export async function evaluateBranchProtection(opts: {
     return { ok: false, code: 'unknown', message: msg };
   }
 
-  let parsed: { required_conversation_resolution?: { enabled?: boolean } };
+  let parsed: {
+    required_conversation_resolution?: { enabled?: boolean };
+    required_status_checks?: { contexts?: string[]; checks?: { context?: string }[] };
+  };
   try {
     parsed = JSON.parse(raw);
   } catch (e) {
@@ -53,6 +61,55 @@ export async function evaluateBranchProtection(opts: {
       message:
         `required_conversation_resolution is not enabled on ${opts.branch}. ` +
         `Enable it: gh api -X PATCH repos/${opts.owner}/${opts.repo}/branches/${opts.branch}/protection/required_conversation_resolution -f enabled=true`,
+    };
+  }
+
+  const classic = parsed.required_status_checks;
+  const classicEnforced =
+    (classic?.contexts?.length ?? 0) > 0 || (classic?.checks?.length ?? 0) > 0;
+  if (classicEnforced) return { ok: true };
+
+  let rulesRaw: string;
+  try {
+    rulesRaw = await opts.ghExec([
+      'api',
+      `repos/${opts.owner}/${opts.repo}/rules/branches/${opts.branch}`,
+    ]);
+  } catch (e) {
+    return {
+      ok: false,
+      code: 'unknown',
+      message: `could not read applied rules for ${opts.branch} (failing closed): ${(e as Error).message}`,
+    };
+  }
+
+  let rules: { type?: string; parameters?: { required_status_checks?: unknown[] } }[];
+  try {
+    rules = JSON.parse(rulesRaw);
+  } catch (e) {
+    return {
+      ok: false,
+      code: 'unknown',
+      message: `non-JSON rules output (failing closed): ${(e as Error).message}`,
+    };
+  }
+
+  const rulesetEnforced =
+    Array.isArray(rules) &&
+    rules.some(
+      (r) =>
+        r.type === 'required_status_checks' &&
+        (r.parameters?.required_status_checks?.length ?? 0) > 0,
+    );
+  if (!rulesetEnforced) {
+    return {
+      ok: false,
+      code: 'required_status_checks_unenforced',
+      message:
+        `no required_status_checks apply to ${opts.branch} — neither classic protection nor any active ruleset targets it, ` +
+        'so a red-CI merge or direct push is not blocked server-side. ' +
+        `Fix: target the ruleset at the default branch, e.g. gh api -X PUT repos/${opts.owner}/${opts.repo}/rulesets/<id> ` +
+        `-f 'conditions[ref_name][include][]=~DEFAULT_BRANCH' -f 'conditions[ref_name][exclude][]='`,
     };
   }
 
@@ -87,7 +144,7 @@ async function main() {
       process.exit(1);
     }
     process.stdout.write(
-      `Branch protection OK (${branch}: required_conversation_resolution=true)\n`,
+      `Branch protection OK (${branch}: required_conversation_resolution=true, required_status_checks enforced)\n`,
     );
     process.exit(0);
   } catch (e) {


### PR DESCRIPTION
## Summary

- Hardens the `ready-to-merge` branch-protection gate (`scripts/check-branch-protection.ts`) to assert that required status checks are actually **enforced** on main — closing the fail-open class discovered today, where the "Default" ruleset held 13 required checks but targeted zero branches (`ref_name.include: []`), so red-CI merges and direct pushes were not blocked server-side while the gate kept printing OK on conversation-resolution alone.
- Detection is two-path with a short-circuit: classic protection (`contexts`/`checks` non-empty) passes without a second API call; otherwise the **applied-rules** endpoint (`rules/branches/<branch>` — effective rules, not configured rulesets) must contain a `required_status_checks` rule with a non-empty check list. A gutted rule (empty list) fails. Rules-query errors and non-JSON output fail closed.
- The new failure (`required_status_checks_unenforced`) names the exact remediation in its message: target the ruleset at `~DEFAULT_BRANCH`.
- **Deliberate consequence:** until the repo's ruleset targeting is fixed, `pnpm ready-to-merge` will fail on every PR — that is this gate detecting the live misconfiguration (verified: running it against the current repo exits 1 with the new code).

## Type of change

- [ ] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [ ] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes (Biome + tsgo typecheck + content + client-naming + harness-size + full test suite)
- [x] New behaviour covered by tests — 13 unit tests via the injected `ghExec` seam: the inert-ruleset incident shape, both enforcement paths (classic short-circuit proven with a call-count assertion; ruleset via applied rules), the gutted-rule case, fail-closed on query error and non-JSON, and conversation-resolution priority. Plus a live negative proof: the gate exits 1 with `required_status_checks_unenforced` against the repo's current real state.

## Visual changes

No UI changes — local CLI merge-gate script + tests only. `pnpm gates:runtime` still run per pre-PR policy: LHCI desktop + mobile, axe-core, chromium e2e all green.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — N/A, script change
- [x] No `use client` added without necessity (RSC drift) — N/A
- [x] Bundle size impact assessed (`pnpm bundle-check`) — zero app surface
- [x] A11y impact considered (axe-core will gate in CI) — N/A, no UI; axe green in runtime gates
- [x] ADR added to `DECISIONS.md` if this changes architecture — not an architecture change; the gate's contract (fail-closed, effective-rules endpoint) is documented in the commit body and test names
