### PR TITLE
ci(gate): always-reporting ci-gate fan-in for required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,6 +563,7 @@ jobs:
         quality-fast,
         typecheck,
         test,
+        dependency-review,
         build,
         performance,
         e2e-functional,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,7 @@ jobs:
               console.log(`${job}: ${n.result}`);
             }
             if (bad.length > 0) {
-              console.error(`ci-gate: blocking — ${bad.map(([job]) => job).join(", ")}`);
+              console.error(`ci-gate: blocking on ${bad.map(([job]) => job).join(", ")}`);
               process.exit(1);
             }
             console.log("ci-gate: all upstream jobs succeeded or were intentionally skipped");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,6 +553,41 @@ jobs:
           name: visual-report-${{ matrix.project }}
           path: test-results/
 
+  ci-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      [
+        detect-changes,
+        quality-fast,
+        typecheck,
+        test,
+        build,
+        performance,
+        e2e-functional,
+        e2e-visual-chromium,
+        ai-eval,
+      ]
+    steps:
+      - name: Gate on upstream job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          node -e '
+            const BAD_RESULTS = new Set(["failure", "cancelled"]);
+            const needs = JSON.parse(process.env.NEEDS_JSON);
+            const bad = Object.entries(needs).filter(([, n]) => BAD_RESULTS.has(n.result));
+            for (const [job, n] of Object.entries(needs)) {
+              console.log(`${job}: ${n.result}`);
+            }
+            if (bad.length > 0) {
+              console.error(`ci-gate: blocking — ${bad.map(([job]) => job).join(", ")}`);
+              process.exit(1);
+            }
+            console.log("ci-gate: all upstream jobs succeeded or were intentionally skipped");
+          '
+
   semgrep:
     name: Semgrep (static analysis)
     runs-on: ubuntu-latest

--- a/__tests__/scripts/ci-gate-job.test.ts
+++ b/__tests__/scripts/ci-gate-job.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const ci = readFileSync(`${process.cwd()}/.github/workflows/ci.yml`, 'utf8');
+
+const jobsSection = ci.slice(ci.indexOf('\njobs:\n') + '\njobs:\n'.length);
+const jobNames = [...jobsSection.matchAll(/^ {2}([A-Za-z0-9_-]+):\s*$/gm)].map((m) => m[1] ?? '');
+
+const gateHeading = '\n  ci-gate:';
+const gateStart = ci.indexOf(gateHeading);
+const rest = ci.slice(gateStart + gateHeading.length);
+const nextJobRel = rest.search(/\n {2}\S/);
+const job =
+  nextJobRel === -1
+    ? ci.slice(gateStart)
+    : ci.slice(gateStart, gateStart + gateHeading.length + nextJobRel);
+
+const needsMatch = job.match(/needs:\s*\[([^\]]*)\]/);
+const needs = (needsMatch?.[1] ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const SELF_REPORTING_JOBS = ['dependency-review', 'semgrep', 'ci-gate'];
+
+describe('ci.yml ci-gate fan-in invariants', () => {
+  it('defines a ci-gate job', () => {
+    expect(gateStart).toBeGreaterThan(-1);
+  });
+
+  it('runs unconditionally (if: always()) so it reports on path-skipped runs', () => {
+    expect(job).toMatch(/if:\s*always\(\)/);
+  });
+
+  it('is not a matrix job (must report exactly one status context)', () => {
+    expect(job).not.toMatch(/matrix:/);
+  });
+
+  it('needs exactly every job except the self-reporting set', () => {
+    expect(jobNames.length).toBeGreaterThan(SELF_REPORTING_JOBS.length);
+    for (const excluded of SELF_REPORTING_JOBS) {
+      expect(jobNames).toContain(excluded);
+    }
+    const expected = jobNames.filter((j) => !SELF_REPORTING_JOBS.includes(j)).sort();
+    expect([...needs].sort()).toEqual(expected);
+  });
+
+  it('blocks on failure and cancelled upstream results only (skipped passes)', () => {
+    expect(job).toMatch(/BAD_RESULTS = new Set\(\["failure", "cancelled"\]\)/);
+  });
+
+  it('reads needs via toJSON into env, never interpolated into the script body', () => {
+    expect(job).toMatch(/NEEDS_JSON:\s*\$\{\{\s*toJSON\(needs\)\s*\}\}/);
+    expect(job).toMatch(/JSON\.parse\(process\.env\.NEEDS_JSON\)/);
+    const runBody = job.slice(job.indexOf('node -e'));
+    expect(runBody).not.toMatch(/\$\{\{/);
+  });
+});

--- a/__tests__/scripts/ci-gate-job.test.ts
+++ b/__tests__/scripts/ci-gate-job.test.ts
@@ -21,7 +21,7 @@ const needs = (needsMatch?.[1] ?? '')
   .map((s) => s.trim())
   .filter(Boolean);
 
-const SELF_REPORTING_JOBS = ['dependency-review', 'semgrep', 'ci-gate'];
+const SELF_REPORTING_JOBS = ['semgrep', 'ci-gate'];
 
 describe('ci.yml ci-gate fan-in invariants', () => {
   it('defines a ci-gate job', () => {

--- a/docs/07-workflows.md
+++ b/docs/07-workflows.md
@@ -69,7 +69,7 @@ flowchart LR
 
 ## CI/CD
 
-`.github/workflows/ci.yml` (the authoritative gate). A `detect-changes` job emits `app`/`ai` booleans so heavy jobs skip on docs-only PRs (GitHub treats skipped required checks as satisfied).
+`.github/workflows/ci.yml` (the authoritative gate). A `detect-changes` job emits `app`/`ai` booleans so heavy jobs skip on docs-only PRs (GitHub treats skipped required checks as satisfied). Matrix jobs skipped at job level report ONE unsuffixed check, so matrix-named required contexts (`e2e-functional (chromium)` etc.) hang forever on path-skipped PRs; required checks therefore point at always-reporting contexts and the conditional jobs are enforced through the `ci-gate` fan-in below.
 
 ```mermaid
 flowchart TD
@@ -85,7 +85,20 @@ flowchart TD
     b --> e2e["e2e-functional (5-project matrix, if app)"]
     b --> vis["e2e-visual-chromium (Argos, if app)"]
     b --> ev["ai-eval (if ai)"]
+    dc --> gate
+    qf --> gate
+    tc --> gate
+    t --> gate
+    dr --> gate
+    b --> gate
+    perf --> gate
+    e2e --> gate
+    vis --> gate
+    ev --> gate
+    gate["ci-gate: always-on fan-in — reds on any failed/cancelled upstream; skipped passes"]
 ```
+
+`ci-gate` runs with `if: always()`, needs every job above (`semgrep` stays outside — report-only by design), and is the terminal required status check. `__tests__/scripts/ci-gate-job.test.ts` asserts its `needs` list equals the full job set minus the self-reporting jobs, so adding a conditional job without fanning it in fails `pnpm test`.
 
 Other workflows: `codeql.yml` (SAST, weekly + PR), `mutation.yml` (Stryker, weekly), `smoke.yml` (post-deploy: healthz + 7 security headers + apex→www + `/api/ask`,`/api/contact` liveness), `claude.yml` (the `@claude` AI-reviewer pilot, doc 06).
 


### PR DESCRIPTION
## Summary

- Fixes the merge deadlock the activated ruleset exposed (live on #182): required contexts use MATRIX names (`e2e-functional (chromium)` …), but a path-gated matrix job skipped at job level reports one unsuffixed `e2e-functional: skipped` check — the suffixed contexts never exist, so scripts/docs-only PRs hang forever on "Expected — Waiting for status". The inverse defect also exists: required unsuffixed `e2e-visual-chromium` only reports when the job is skipped; on UI PRs only matrix-suffixed names report, so UI PRs would hang on it.
- Adds an always-reporting `ci-gate` fan-in job: `if: always()`, `needs` every conditional job, fails when any upstream result is `failure`/`cancelled`, passes on `success`/`skipped` (path-skips are intentional). Enforcement of the conditional jobs moves inside the gate with identical strictness — a red matrix leg makes `e2e-functional`'s result `failure`, which reds the gate, which blocks merge.
- Fans `dependency-review` into the gate too (battery security finding): its verdict (`fail-on-severity: high` + GPL/AGPL license denial) was not among the ruleset's required contexts, so a red run never blocked merge. It is PR-only, so on main pushes it reports `skipped`, which passes the gate; on PRs it always runs. This is a deliberate strictness increase.
- Adds a guard test (`__tests__/scripts/ci-gate-job.test.ts`) asserting `ci-gate.needs` equals the full ci.yml job set minus the self-reporting jobs (`semgrep`, `ci-gate`) — a future conditional job added without a needs entry now fails `pnpm test` instead of silently re-introducing the hang class.
- Verified against the live ruleset: Argos and webkit coverage are unchanged — Argos is not a required context today (visual verdict stays advisory; making it required is a separate owner decision), and the webkit e2e legs are required today, so ci-gate reading the `e2e-functional` aggregate preserves identical strictness.
- **Owner action after merge** (repo security setting): update the ruleset's required checks to the always-reporting set — `quality-fast`, `typecheck`, `test`, `build`, `detect-changes`, `ci-gate` — replacing the current 13. I'll supply the exact API call and verify, as with the targeting fix.

## Type of change

- [ ] `feat` — new functionality
- [ ] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes in the pre-push verify chain
- [x] New behaviour covered by tests — the gate's own semantics are exercised by THIS PR's CI run: the workflow change triggers the full matrix (`.github/workflows/` is in the detect-changes app paths), so `ci-gate` runs with all-success upstreams and must pass; yaml validated by parse. The skip-path semantics get their live proof on the next scripts-only PR (#182 after rebase).

## Visual changes

No UI changes — CI workflow only.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — result names are the GitHub Actions enum, held in a named set
- [x] No `use client` added without necessity (RSC drift) — N/A
- [x] Bundle size impact assessed (`pnpm bundle-check`) — zero app surface
- [x] A11y impact considered (axe-core will gate in CI) — N/A
- [x] ADR added to `DECISIONS.md` if this changes architecture — the required-checks strategy is documented in this PR + the ruleset change record; will fold into DECISIONS.md with the ruleset update if the owner prefers

