### PR TITLE
feat(security): make gitleaks actually run and prove it fires; gate the .gitignore meta-gate against its own drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,6 +569,7 @@ jobs:
         e2e-functional,
         e2e-visual-chromium,
         ai-eval,
+        gitleaks,
       ]
     steps:
       - name: Gate on upstream job results
@@ -634,4 +635,72 @@ jobs:
         with:
           sarif_file: semgrep.sarif
           category: semgrep
+
+  gitleaks:
+    name: Gitleaks (secret scan)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    concurrency:
+      group: gitleaks-${{ github.ref }}
+      cancel-in-progress: true
+    env:
+      GITLEAKS_VERSION: 8.30.0
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0   # gitleaks scans history, not just the tip
+
+      - name: Install gitleaks (exact-pinned)
+        run: |
+          curl -sSfL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          rm -f gitleaks gitleaks.tar.gz
+          installed="$(gitleaks version)"
+          if [ "$installed" != "$GITLEAKS_VERSION" ]; then
+            echo "::error::gitleaks reports version '$installed', expected '$GITLEAKS_VERSION'. Refusing to scan with an unknown binary."
+            exit 1
+          fi
+
+      # Proves the scanner FIRES. A secret scan that finds nothing is indistinguishable
+      # from a scanner that is silently broken, so this plants a real secret and fails
+      # the job unless gitleaks detects it (and stays silent on the clean fixture).
+      - name: Self-test - gitleaks fires on the fixture
+        run: node scripts/check-gitleaks-fixture.mjs
+
+      - name: Scan the repository and its history
+        run: |
+          set +e
+          gitleaks git . --no-banner --redact --config .gitleaks.toml \
+            --report-format sarif --report-path gitleaks.sarif
+          status=$?
+          set -e
+          echo "GITLEAKS_STATUS=$status" >> "$GITHUB_ENV"
+          if [ ! -s gitleaks.sarif ]; then
+            echo '::error::gitleaks produced no SARIF; the scan did not run. This is an infra failure, not a clean result -- do not read it as "no secrets".'
+            exit 1
+          fi
+
+      - name: Fail on findings
+        run: |
+          if [ "$GITLEAKS_STATUS" -eq 1 ]; then
+            echo '::error::gitleaks found a secret. Values are redacted in the log; see the SARIF artifact. Rotate the credential -- it is already in git history.'
+            exit 1
+          fi
+          if [ "$GITLEAKS_STATUS" -ne 0 ]; then
+            echo "::error::gitleaks exited $GITLEAKS_STATUS (neither 0=clean nor 1=leaks). Treating an unknown exit code as clean would be a fail-open."
+            exit 1
+          fi
+          echo 'gitleaks: clean'
+
+      - name: Upload SARIF artifact
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: gitleaks-sarif
+          path: gitleaks.sarif
+          retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,16 +652,30 @@ jobs:
         with:
           fetch-depth: 0   # gitleaks scans history, not just the tip
 
-      - name: Install gitleaks (exact-pinned)
+      # Verified by CHECKSUM, not by asking the binary what it is: a tampered binary can
+      # print any version string it likes. The repo SHA-pins its Actions and exact-pins
+      # semgrep; a curl'd tarball has to clear the same bar.
+      - name: Install gitleaks (checksum-verified, exact-pinned)
         run: |
-          curl -sSfL -o gitleaks.tar.gz \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          tar -xzf gitleaks.tar.gz gitleaks
+          base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL -o "$tarball" "$base/$tarball"
+          curl -sSfL -o checksums.txt "$base/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+
+          expected="$(awk -v f="$tarball" '$2 == f { print $1 }' checksums.txt)"
+          if [ -z "$expected" ]; then
+            echo "::error::no checksum for $tarball in the release checksums file. Refusing to install an unverified binary."
+            exit 1
+          fi
+          echo "${expected}  ${tarball}" | sha256sum -c -
+
+          tar -xzf "$tarball" gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
-          rm -f gitleaks gitleaks.tar.gz
+          rm -f gitleaks "$tarball" checksums.txt
+
           installed="$(gitleaks version)"
           if [ "$installed" != "$GITLEAKS_VERSION" ]; then
-            echo "::error::gitleaks reports version '$installed', expected '$GITLEAKS_VERSION'. Refusing to scan with an unknown binary."
+            echo "::error::gitleaks reports version '$installed', expected '$GITLEAKS_VERSION'."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,7 @@ jobs:
       # semgrep; a curl'd tarball has to clear the same bar.
       - name: Install gitleaks (checksum-verified, exact-pinned)
         run: |
+          set -euo pipefail   # explicit: the sha256sum -c below must abort the step, not just print
           base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
           tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           curl -sSfL -o "$tarball" "$base/$tarball"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,21 +10,24 @@ paths = [
   '''__tests__/color-swatch.test.tsx''',
 ]
 
-# Both fixtures plant a real-looking secret on purpose, to prove their scanner FIRES.
-# Each self-test copies its fixture OUT of the repo and scans it without this config,
-# so allowlisting here cannot weaken either gate -- but without it, the repo scan reds
-# on our own bait.
+# Both fixtures plant a fake-but-real-shaped secret on purpose, to prove their scanner FIRES.
+# These allowlists exempt the planted VALUE, not the file.
+#
+# Measured on gitleaks 8.30: ANY `paths` entry exempts the file from EVERY rule, and neither
+# `condition = "AND"` nor `matchCondition = "AND"` narrows that -- both still allowlist the
+# whole file. A path-scoped entry would therefore make these two fixtures permanent
+# secret-laundering paths: a REAL credential parked in one of them would be invisible to the
+# scanner forever. A `regexes`-only entry does not have that property, so any other secret in
+# the same file is still caught. Verified both ways in scripts/__tests__.
+#
+# The exempted values are fake and we own them, so exempting them repo-wide costs nothing.
 [[allowlists]]
-description = "Planted secret proving gitleaks fires (scripts/check-gitleaks-fixture.mjs asserts it is detected)"
-paths = [
-  '''tests/fixtures/gitleaks/leaky\.ts''',
-]
+description = "Planted token proving gitleaks fires (scripts/check-gitleaks-fixture.mjs asserts it is detected)"
+regexes = ['''ghp_R2d2c3poAbCdEfGhIjKlMnOpQrStUvWx1234''']
 
 [[allowlists]]
-description = "Planted secret proving semgrep fires (scripts/check-semgrep-fixture.mjs asserts hardcoded-stripe-secret-key)"
-paths = [
-  '''tests/fixtures/semgrep/vulnerable\.ts''',
-]
+description = "Planted token proving semgrep fires (scripts/check-semgrep-fixture.mjs asserts hardcoded-stripe-secret-key)"
+regexes = ['''sk_test_51HxFakeFixtureTokenABCDEFGHIJ''']
 
 [[allowlists]]
 description = "CSS design token names (secondary-NNN) in design-system docs"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,6 +10,22 @@ paths = [
   '''__tests__/color-swatch.test.tsx''',
 ]
 
+# Both fixtures plant a real-looking secret on purpose, to prove their scanner FIRES.
+# Each self-test copies its fixture OUT of the repo and scans it without this config,
+# so allowlisting here cannot weaken either gate -- but without it, the repo scan reds
+# on our own bait.
+[[allowlists]]
+description = "Planted secret proving gitleaks fires (scripts/check-gitleaks-fixture.mjs asserts it is detected)"
+paths = [
+  '''tests/fixtures/gitleaks/leaky\.ts''',
+]
+
+[[allowlists]]
+description = "Planted secret proving semgrep fires (scripts/check-semgrep-fixture.mjs asserts hardcoded-stripe-secret-key)"
+paths = [
+  '''tests/fixtures/semgrep/vulnerable\.ts''',
+]
+
 [[allowlists]]
 description = "CSS design token names (secondary-NNN) in design-system docs"
 paths = [

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,12 +3,16 @@ title = "gitleaks configuration"
 [extend]
 useDefault = true
 
+# NO ALLOWLIST IN THIS FILE MAY USE `paths`. A `paths` entry exempts the file from EVERY
+# rule, which makes it a permanent secret-laundering path: a real credential committed there
+# would be invisible to the scanner forever. These three entries were `paths` until it was
+# measured -- sanitize-secrets.test.ts is a test ABOUT redacting real-shaped tokens, i.e. the
+# likeliest file in the repo for a real one to be pasted into, and it was exempt from
+# everything. Allowlist the VALUE, never the file. scripts/check-gitleaks-fixture.mjs fails
+# the build if a `paths` key reappears here.
 [[allowlists]]
-description = "Fake GitHub tokens used as test fixtures in sanitize-secrets tests"
-paths = [
-  '''__tests__/scripts/sanitize-secrets.test.ts''',
-  '''__tests__/color-swatch.test.tsx''',
-]
+description = "Fake GitHub tokens asserted by the sanitize-secrets tests (generic-api-key false positives)"
+regexes = ['''^gh[psour]_AbCdEf0123456789012345$''']
 
 # Both fixtures plant a fake-but-real-shaped secret on purpose, to prove their scanner FIRES.
 # These allowlists exempt the planted VALUE, not the file.
@@ -30,7 +34,5 @@ description = "Planted token proving semgrep fires (scripts/check-semgrep-fixtur
 regexes = ['''sk_test_51HxFakeFixtureTokenABCDEFGHIJ''']
 
 [[allowlists]]
-description = "CSS design token names (secondary-NNN) in design-system docs"
-paths = [
-  '''app/design-system/tokens/page.mdx''',
-]
+description = "CSS design token names (secondary-NNN), not secrets (generic-api-key false positives)"
+regexes = ['''^secondary-\d{2,3}$''']

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 
 pnpm check
+pnpm gitleaks:staged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ Full rationale in `STANDARDS.md`. Load that file when a chapter is directly rele
 | 8 — A11y | axe-core gate + Lighthouse =100; per-component behavioral a11y tests |
 | 9 — Security | Behavioral tests for CSP + kill switches (not source-grep); `security-auditor` on any `app/api/` change |
 | 10 — Docs | PR review: doc claims must match live code; ADRs cite SHA + reversibility note |
-| 11 — DX | pre-commit = Biome (<1s) + `gitleaks --staged` (~0.4s, fails closed if the binary is missing — `brew install gitleaks`) + commitlint (scope required, error on missing); pre-push = full verify + branch-name `<type>/<description>` enforced; never disable a gate to merge |
+| 11 — DX | pre-commit = Biome (<1s) + `gitleaks git --staged` (~0.4s, fails closed if the binary is missing — `brew install gitleaks`) + commitlint (scope required, error on missing); pre-push = full verify + branch-name `<type>/<description>` enforced; never disable a gate to merge |
 | 12 — Design system | `lint:contrast` + component-docs CI gates |
 
 **Hook authoring:** `.claude/hooks/*` PreToolUse guards that must BLOCK a tool call exit with code **2** (exit 1 is a non-blocking warning — the command still runs). `bash-guard.sh` blocks (broad `git add`, npm/yarn, `gh pr merge`, force-push, fallow non-read-only) use `exit 2`; verify a guard blocks with a live test, not its printed `[BLOCKED]` message.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ Full rationale in `STANDARDS.md`. Load that file when a chapter is directly rele
 | 8 — A11y | axe-core gate + Lighthouse =100; per-component behavioral a11y tests |
 | 9 — Security | Behavioral tests for CSP + kill switches (not source-grep); `security-auditor` on any `app/api/` change |
 | 10 — Docs | PR review: doc claims must match live code; ADRs cite SHA + reversibility note |
-| 11 — DX | pre-commit = Biome (<1s) + commitlint (scope required, error on missing); pre-push = full verify + branch-name `<type>/<description>` enforced; never disable a gate to merge |
+| 11 — DX | pre-commit = Biome (<1s) + `gitleaks --staged` (~0.4s, fails closed if the binary is missing — `brew install gitleaks`) + commitlint (scope required, error on missing); pre-push = full verify + branch-name `<type>/<description>` enforced; never disable a gate to merge |
 | 12 — Design system | `lint:contrast` + component-docs CI gates |
 
 **Hook authoring:** `.claude/hooks/*` PreToolUse guards that must BLOCK a tool call exit with code **2** (exit 1 is a non-blocking warning — the command still runs). `bash-guard.sh` blocks (broad `git add`, npm/yarn, `gh pr merge`, force-push, fallow non-read-only) use `exit 2`; verify a guard blocks with a live test, not its printed `[BLOCKED]` message.

--- a/__tests__/meta/gitignore-worktree-symlinks.test.ts
+++ b/__tests__/meta/gitignore-worktree-symlinks.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { type SpawnSyncReturns, spawnSync } from 'node:child_process';
 import { copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -17,10 +17,11 @@ const GIT_PATH_IGNORED = 0;
 const GIT_PATH_NOT_IGNORED = 1;
 
 type Shape = 'symlink' | 'directory';
+type GitResult = SpawnSyncReturns<Buffer>;
 
 const hermeticEnv = (): NodeJS.ProcessEnv => {
   const env: NodeJS.ProcessEnv = {
-    NODE_ENV: process.env.NODE_ENV ?? 'test',
+    NODE_ENV: 'test',
     GIT_CONFIG_GLOBAL: NULL_DEVICE,
     GIT_CONFIG_SYSTEM: NULL_DEVICE,
     GIT_CONFIG_NOSYSTEM: '1',
@@ -38,25 +39,29 @@ const git = (cwd: string, args: string[]) =>
 
 const NOT_FOUND = 'ENOENT';
 
-const describeGitFailure = (result: ReturnType<typeof git>) => {
-  if (result.error === undefined) {
-    return `it exited ${result.status}: ${String(result.stderr).trim()}`;
+const describeGitFailure = (result: GitResult) => {
+  if (result.error !== undefined) {
+    const spawned = `git could not be spawned: ${result.error.message}`;
+    return result.error.message.includes(NOT_FOUND)
+      ? `${spawned} (the child gets an allowlisted PATH, and git is not reachable on it)`
+      : spawned;
   }
-  const spawned = `git could not be spawned at all: ${result.error.message}`;
-  return result.error.message.includes(NOT_FOUND)
-    ? `${spawned}. This sandbox gives the child an allowlisted environment (${ENV_ALLOWLIST.join(', ')}), so git is not reachable via that PATH.`
-    : spawned;
+  if (result.signal !== null) {
+    return `git was killed by ${result.signal} before it could answer`;
+  }
+  return `git exited ${result.status}: ${String(result.stderr).trim()}`;
 };
 
-const gitAnswered = (result: ReturnType<typeof git>) =>
+const gitAnswered = (result: GitResult) =>
   result.error === undefined &&
+  result.signal === null &&
   (result.status === GIT_PATH_IGNORED || result.status === GIT_PATH_NOT_IGNORED);
 
 const isIgnored = (cwd: string, target: string) => {
   const result = git(cwd, ['check-ignore', '-q', '--', target]);
   if (!gitAnswered(result)) {
     throw new Error(
-      `git check-ignore on "${target}" answered neither ${GIT_PATH_IGNORED} (ignored) nor ${GIT_PATH_NOT_IGNORED} (not ignored): ${describeGitFailure(result)}. git did not answer the question, so this is not a verdict on the .gitignore rule. Reporting it as "not ignored" would red the assertion below and send you to edit a rule that may be fine.`,
+      `git check-ignore on "${target}" did not answer ${GIT_PATH_IGNORED} (ignored) or ${GIT_PATH_NOT_IGNORED} (not ignored): ${describeGitFailure(result)}. Nothing was learned about the .gitignore rule here, so do not go and edit it: reporting this as "not ignored" would red the assertion below and send you after a rule that may be fine.`,
     );
   }
   return result.status === GIT_PATH_IGNORED;
@@ -71,7 +76,7 @@ const makeSandbox = (shape: Shape) => {
   const init = git(dir, ['init', '-q', EMPTY_INIT_TEMPLATE]);
   if (init.status !== GIT_OK) {
     throw new Error(
-      `git init failed in the ${shape} sandbox: ${describeGitFailure(init)}. Every case below would then red for that reason while blaming the .gitignore rule.`,
+      `git init failed in the ${shape} sandbox: ${describeGitFailure(init)}. No case below can run against this sandbox.`,
     );
   }
 
@@ -101,6 +106,37 @@ afterAll(() => {
 const siblingsOf = (name: string) => HARNESS_SYMLINKS.filter((other) => other !== name).join(', ');
 const childEnvKeys = () => Object.keys(hermeticEnv()).sort().join(', ');
 
+const TRACKED_FILE = 'package.json';
+
+const gitResult = (over: Partial<GitResult>): GitResult => ({
+  pid: 0,
+  output: [],
+  stdout: Buffer.from(''),
+  stderr: Buffer.from(''),
+  status: GIT_PATH_IGNORED,
+  signal: null,
+  ...over,
+});
+
+const FAILURE_SHAPES: Array<[string, GitResult, string]> = [
+  [
+    'binary missing',
+    gitResult({ status: null, error: new Error('spawnSync git ENOENT') }),
+    'ENOENT',
+  ],
+  [
+    'permission denied',
+    gitResult({ status: null, error: new Error('spawnSync git EACCES') }),
+    'EACCES',
+  ],
+  ['killed by a signal', gitResult({ status: null, signal: 'SIGKILL' }), 'SIGKILL'],
+  [
+    'git ran and refused',
+    gitResult({ status: 128, stderr: Buffer.from('fatal: not a git repository') }),
+    'not a git repository',
+  ],
+];
+
 describe('meta: .gitignore covers the paths the agent-worktree harness symlinks', () => {
   it.each(HARNESS_SYMLINKS)('%s is ignored when materialised as a symlink', (name) => {
     expect(
@@ -118,6 +154,46 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
     expect(
       directoryIgnored && contentsIgnored,
       `The rule for "${name}" must keep ignoring the REAL ${name} directory and everything inside it. In the main tree ${name} is a real directory, not the symlink the sibling case covers. Measured here: directory ignored = ${directoryIgnored}, contents ignored = ${contentsIgnored}.\n\nIf BOTH are false, no rule matches ${name} at all and everything inside it becomes committable. That is the outcome this case exists to prevent, and it is the direction a well-meaning edit to the symlink case can silently break.\n\nIf only the directory is false, the rule matches below ${name} but not ${name} itself -- the "/${name}/**" shape. Nothing becomes committable then, because the contents are still ignored. But that shape does not match a symlink either, so the sibling case above is red too, and that is the one to fix.\n\nMeasured forms: "/${name}" satisfies this case and the symlink case; "/${name}/" misses the symlink; "/${name}/**" misses the symlink and this directory. An unanchored "${name}" satisfies all of them as well -- so nothing in this file holds the leading "/". The anchor is there to stop the rule matching a nested ${name} at any depth, and no test here asserts that.`,
+    ).toBe(true);
+  });
+
+  it('a tracked file is NOT ignored, so the sandbox can still tell the cases apart', () => {
+    expect(
+      isIgnored(sandboxes.symlink, TRACKED_FILE),
+      `The sandbox reports "${TRACKED_FILE}" as ignored, which means it would report almost anything as ignored -- a .gitignore with a stray "*" does exactly that. Both cases above would then pass while proving nothing, because they only ever ask "is this path ignored?" and the answer had become yes for everything. This is the positive control: it is the assertion that keeps a green run meaningful.`,
+    ).toBe(false);
+  });
+});
+
+describe('meta: the gate says what actually went wrong when git does not answer', () => {
+  it.each(FAILURE_SHAPES)('%s is named in the message', (_shape, result, expected) => {
+    const described = describeGitFailure(result);
+
+    expect(
+      described.includes(expected),
+      `describeGitFailure() rendered "${described}", which does not name "${expected}".\n\nThese messages are the only thing a future engineer reads when this gate reds, and NO passing run ever renders them -- which is exactly why they drifted through six review rounds while the suite stayed green. They are asserted here so they cannot drift again.`,
+    ).toBe(true);
+
+    expect(
+      described.includes('null') || described.includes('undefined'),
+      `describeGitFailure() rendered "${described}". A message that says "null" has told the reader nothing: spawnSync reports status=null for BOTH a missing binary and a signal-killed child, and stderr is null in both. Read result.error and result.signal instead.`,
+    ).toBe(false);
+  });
+
+  it.each(FAILURE_SHAPES)('%s counts as git not having answered', (_shape, result) => {
+    expect(
+      gitAnswered(result),
+      `gitAnswered() accepted a result where git did not answer. Only exit ${GIT_PATH_IGNORED} (ignored) and exit ${GIT_PATH_NOT_IGNORED} (not ignored) are answers. Accepting anything else lets a broken sandbox be read as a verdict on the .gitignore rule -- and if it were read as "ignored", this gate would go GREEN while the rule under test is broken.`,
+    ).toBe(false);
+  });
+
+  it.each([
+    ['ignored', GIT_PATH_IGNORED],
+    ['not ignored', GIT_PATH_NOT_IGNORED],
+  ])('a real answer (%s) is not mistaken for a failure', (_label, status) => {
+    expect(
+      gitAnswered(gitResult({ status })),
+      `gitAnswered() rejected exit ${status}, which is a genuine answer from git. Rejecting it would make the gate throw on a legitimate result -- the false-positive mirror of the fail-open, and the thing that trains people to disable a gate.`,
     ).toBe(true);
   });
 });

--- a/__tests__/meta/gitignore-worktree-symlinks.test.ts
+++ b/__tests__/meta/gitignore-worktree-symlinks.test.ts
@@ -14,6 +14,7 @@ const EMPTY_INIT_TEMPLATE = '--template=';
 const ENV_ALLOWLIST = ['PATH', 'TMPDIR'];
 const GIT_OK = 0;
 const GIT_PATH_IGNORED = 0;
+const GIT_PATH_NOT_IGNORED = 1;
 
 type Shape = 'symlink' | 'directory';
 
@@ -35,8 +36,15 @@ const hermeticEnv = (): NodeJS.ProcessEnv => {
 const git = (cwd: string, args: string[]) =>
   spawnSync('git', [...NO_GLOBAL_EXCLUDES, ...args], { cwd, env: hermeticEnv() });
 
-const isIgnored = (cwd: string, target: string) =>
-  git(cwd, ['check-ignore', '-q', '--', target]).status === GIT_PATH_IGNORED;
+const isIgnored = (cwd: string, target: string) => {
+  const { status, stderr } = git(cwd, ['check-ignore', '-q', '--', target]);
+  if (status !== GIT_PATH_IGNORED && status !== GIT_PATH_NOT_IGNORED) {
+    throw new Error(
+      `git check-ignore on "${target}" exited ${status}, which is neither ${GIT_PATH_IGNORED} (ignored) nor ${GIT_PATH_NOT_IGNORED} (not ignored): ${stderr}. Treating that as "not ignored" would red the assertion below and blame the .gitignore rule for what is actually a broken sandbox.`,
+    );
+  }
+  return status === GIT_PATH_IGNORED;
+};
 
 const sandboxes: Record<Shape, string> = { symlink: '', directory: '' };
 
@@ -81,7 +89,7 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
   it.each(HARNESS_SYMLINKS)('%s is ignored when materialised as a symlink', (name) => {
     expect(
       isIgnored(sandboxes.symlink, name),
-      `The harness symlinks "${name}" into every agent worktree, and this .gitignore does not ignore it.\n\nGit lstats a path and never follows the link, so a symlink is not a directory: a directory-only rule ("/${name}/", with a trailing slash) cannot match it. The worktree then carries a phantom "?? ${name}" that no rule covers and that a "git clean -fd" would delete, severing the link to the main tree. Write "/${name}" instead — slashless, root-anchored — which matches a real directory and a symlink alike.\n\nCompare against the other harness path here (${siblingsOf(name)}). If any of those is green while this is red, the difference is in this rule alone: either it grew a trailing slash, or it went missing.\n\nThis sandbox is deliberately hermetic, because a SECOND ignore source can mask a broken rule and turn this gate GREEN while the rule is still wrong -- the one outcome it exists to prevent. The child git therefore runs on an allowlisted environment (${childEnvKeys()}), so every variable that could point it at another ignore file is absent rather than out-ranked: GIT_DIR (a foreign .git/info/exclude), GIT_TEMPLATE_DIR (a seeded one), the GIT_CONFIG_KEY_n pairs, and HOME / XDG_CONFIG_HOME (~/.config/git/ignore). Each was measured: point any one of them at a file listing "${name}", and a NON-hermetic check reports a broken rule as ignored. core.excludesFile is still pinned to ${NULL_DEVICE} and the init template is empty, but nothing depends on those any more -- removal does not rely on git's config precedence staying what it is today.`,
+      `The harness symlinks "${name}" into every agent worktree, and this .gitignore does not ignore it.\n\nWrite "/${name}": root-anchored, no trailing slash. A trailing slash makes a rule directory-only, and git lstats a path without following the link, so "/${name}/" cannot match a symlink. The slashless form matches the symlink, the real directory, and the directory's contents -- the sibling case in this file asserts those last two, so check it before widening this rule.\n\nOther harness paths asserted here: ${siblingsOf(name)}.\n\nThe sandbox runs git on an allowlisted environment (${childEnvKeys()}), with an empty init template and core.excludesFile pinned to ${NULL_DEVICE}. That is not incidental: any ambient ignore source -- a foreign GIT_DIR's info/exclude, a seeded template, a user or system ignore file -- would be a SECOND place the path could get ignored, and this gate would then read GREEN while the rule under test is broken. If you relax the sandbox, this test can start passing for a reason that has nothing to do with .gitignore.`,
     ).toBe(true);
   });
 

--- a/__tests__/meta/gitignore-worktree-symlinks.test.ts
+++ b/__tests__/meta/gitignore-worktree-symlinks.test.ts
@@ -43,7 +43,7 @@ const describeGitFailure = (result: GitResult) => {
   if (result.error !== undefined) {
     const spawned = `git could not be spawned: ${result.error.message}`;
     return result.error.message.includes(NOT_FOUND)
-      ? `${spawned} (the child gets an allowlisted PATH, and git is not reachable on it)`
+      ? `${spawned} (ENOENT means either git is not on the allowlisted PATH, or the sandbox directory is gone)`
       : spawned;
   }
   if (result.signal !== null) {
@@ -153,7 +153,7 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
 
     expect(
       directoryIgnored && contentsIgnored,
-      `The rule for "${name}" must keep ignoring the REAL ${name} directory and everything inside it. In the main tree ${name} is a real directory, not the symlink the sibling case covers. Measured here: directory ignored = ${directoryIgnored}, contents ignored = ${contentsIgnored}.\n\nIf BOTH are false, no rule matches ${name} at all and everything inside it becomes committable. That is the outcome this case exists to prevent, and it is the direction a well-meaning edit to the symlink case can silently break.\n\nIf only the directory is false, the rule matches below ${name} but not ${name} itself -- the "/${name}/**" shape. Nothing becomes committable then, because the contents are still ignored. But that shape does not match a symlink either, so the sibling case above is red too, and that is the one to fix.\n\nMeasured forms: "/${name}" satisfies this case and the symlink case; "/${name}/" misses the symlink; "/${name}/**" misses the symlink and this directory. An unanchored "${name}" satisfies all of them as well -- so nothing in this file holds the leading "/". The anchor is there to stop the rule matching a nested ${name} at any depth, and no test here asserts that.`,
+      `The rule for "${name}" must keep ignoring the REAL ${name} directory and everything inside it. In the main tree ${name} is a real directory, not the symlink the sibling case covers. Measured here: directory ignored = ${directoryIgnored}, contents ignored = ${contentsIgnored}.\n\nIf BOTH are false, nothing leaves ${name} ignored and everything inside it becomes committable. Do not read that as "the rule is missing" -- grep first, because a rule can be present and still lose: measured, "/${name}" followed by a negation "!/${name}/" re-includes the directory and stages its contents. Either way this is the outcome the case exists to prevent, and it is the direction a well-meaning edit to the symlink case can silently break.\n\nIf only the directory is false, the rule matches below ${name} but not ${name} itself -- the "/${name}/**" shape. Nothing under the real directory becomes committable then, because its contents are still ignored. The worktree symlink does, though: measured, "/${name}/**" leaves the symlink unignored and "git add" stages it as a symlink blob holding an absolute path to one machine. So the sibling case above is red too, and it is the one to fix.\n\nMeasured forms: "/${name}" satisfies this case and the symlink case; "/${name}/" misses the symlink; "/${name}/**" misses the symlink and this directory. An unanchored "${name}" satisfies all of them as well -- so nothing in this file holds the leading "/". The anchor is there to stop the rule matching a nested ${name} at any depth, and no test here asserts that.`,
     ).toBe(true);
   });
 

--- a/__tests__/meta/gitignore-worktree-symlinks.test.ts
+++ b/__tests__/meta/gitignore-worktree-symlinks.test.ts
@@ -142,7 +142,7 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
   it.each(HARNESS_SYMLINKS)('%s is ignored when materialised as a symlink', (name) => {
     expect(
       isIgnored(sandboxes.symlink, name),
-      `The harness symlinks "${name}" into every agent worktree, and this .gitignore does not ignore it.\n\nWrite "/${name}", with no trailing slash. A trailing slash makes a rule directory-only, and git lstats a path without following the link, so a symlink is not a directory and "/${name}/" cannot match it. Measured: "/${name}" matches the symlink, the real directory, and the directory's contents; "/${name}/" misses the symlink; "/${name}/**" misses the symlink and the directory. The sibling case in this file asserts the directory and its contents, so read it before widening this rule.\n\nOther harness paths asserted here: ${siblingsOf(name)}.\n\nThe child git sees exactly these variables: ${childEnvKeys()}. Only ${ENV_ALLOWLIST.join(' and ')} are inherited; the rest are injected here, alongside an empty init template and core.excludesFile=${NULL_DEVICE}. That is deliberate. An ambient ignore source -- a foreign GIT_DIR's info/exclude, a seeded template, a user or system ignore file -- is a SECOND place "${name}" could get ignored, and this gate would then read GREEN while the rule under test is broken. Relax the sandbox and this test can start passing for a reason that has nothing to do with .gitignore.`,
+      `The harness symlinks "${name}" into every agent worktree, and this .gitignore does not ignore it.\n\nWrite "/${name}", with no trailing slash. A trailing slash makes a rule directory-only, and git lstats a path without following the link, so a symlink is not a directory and a directory-only rule cannot match it.\n\nEvery rule shape, measured against git (this table is rendered from the same data the matrix in this file asserts, so it cannot drift from what git actually does):\n\n${shapeTable(name)}\n\nOther harness paths asserted here: ${siblingsOf(name)}.\n\nThe child git sees exactly these variables: ${childEnvKeys()}. Only ${ENV_ALLOWLIST.join(' and ')} are inherited from the parent; the rest are set here. That allowlist is the whole defence, and it works by ABSENCE: GIT_DIR (a foreign info/exclude), HOME and XDG_CONFIG_HOME (a user ignore file), GIT_TEMPLATE_DIR (a seeded one) and the GIT_CONFIG_* family are each a SECOND place "${name}" could get ignored, and any one of them would turn this gate GREEN while the rule under test is broken. Measured: leak any one of them into the child and a broken rule reads as ignored.\n\nThe empty init template and core.excludesFile=${NULL_DEVICE} are backstops, not load-bearing -- measured: with the allowlist alone and both of those removed, a broken rule still reds. Do not "simplify" the allowlist on the grounds that the pins cover it. They do not; it is the other way round.`,
     ).toBe(true);
   });
 
@@ -154,7 +154,7 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
 
     expect(
       directoryIgnored && contentsIgnored,
-      `The rule for "${name}" must keep ignoring the REAL ${name} directory and everything inside it. In the main tree ${name} is a real directory, not the symlink the sibling case covers. Measured here: directory ignored = ${directoryIgnored}, contents ignored = ${contentsIgnored}.\n\nIf BOTH are false, nothing leaves ${name} ignored and everything inside it becomes committable. Do not read that as "the rule is missing" -- grep first, because a rule can be present and still lose: measured, "/${name}" followed by a negation "!/${name}/" re-includes the directory and stages its contents. Either way this is the outcome the case exists to prevent, and it is the direction a well-meaning edit to the symlink case can silently break.\n\nIf only the directory is false, the rule matches below ${name} but not ${name} itself -- the "/${name}/**" shape. Nothing under the real directory becomes committable then, because its contents are still ignored. The worktree symlink does, though: measured, "/${name}/**" leaves the symlink unignored and "git add" stages it as a symlink blob holding an absolute path to one machine. So the sibling case above is red too, and it is the one to fix.\n\nMeasured forms: "/${name}" satisfies this case and the symlink case; "/${name}/" misses the symlink; "/${name}/**" misses the symlink and this directory. An unanchored "${name}" satisfies all of them as well -- so nothing in this file holds the leading "/". The anchor is there to stop the rule matching a nested ${name} at any depth, and no test here asserts that.`,
+      `The rule for "${name}" must keep ignoring the REAL ${name} directory and everything inside it. In the main tree ${name} is a real directory, not the symlink the sibling case covers. Measured here: directory ignored = ${directoryIgnored}, contents ignored = ${contentsIgnored}.\n\nIf BOTH are false, nothing leaves ${name} ignored and everything inside it becomes committable. Do not read that as "the rule is missing" -- grep first, because a rule can be present and still lose: measured, "/${name}" followed by a negation "!/${name}/" re-includes the directory and stages its contents. Either way this is the outcome the case exists to prevent, and it is the direction a well-meaning edit to the symlink case can silently break.\n\nIf only the directory is false, the rule matches below ${name} but not ${name} itself -- the "/${name}/**" shape. Nothing under the real directory becomes committable then, because its contents are still ignored. The worktree symlink does, though: measured, "/${name}/**" leaves the symlink unignored and "git add" stages it as a symlink blob holding an absolute path to one machine. So the sibling case above is red too, and it is the one to fix.\n\nEvery rule shape, measured against git (rendered from the same data the matrix in this file asserts, so it cannot drift):\n\n${shapeTable(name)}\n\nNote what that table says about the leading "/": an unanchored "${name}" satisfies this case and the symlink case too. The anchor is not what those cases hold. It is there to stop the rule matching a nested ${name} at any depth, which is the only column that tells the two apart.`,
     ).toBe(true);
   });
 
@@ -167,27 +167,33 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
 });
 
 const RULE = 'X';
+const NESTED_DIR = 'nested';
 const NEGATED = `/${RULE}\n!/${RULE}/`;
 
-const makeRuleSandbox = (rule: string, shape: Shape) => {
+type Materialisation = 'symlink' | 'directory' | 'nested';
+
+const makeRuleSandbox = (rule: string, as: Materialisation) => {
   const dir = mkdtempSync(path.join(tmpdir(), 'gitignore-rule-'));
   const init = git(dir, ['init', '-q', EMPTY_INIT_TEMPLATE]);
   if (init.status !== GIT_OK) {
     throw new Error(`git init failed in the rule sandbox: ${describeGitFailure(init)}.`);
   }
   writeFileSync(path.join(dir, '.gitignore'), `${rule}\n`);
-  if (shape === 'symlink') {
+  if (as === 'symlink') {
     mkdirSync(path.join(dir, SYMLINK_TARGET));
     symlinkSync(SYMLINK_TARGET, path.join(dir, RULE));
-  } else {
+  } else if (as === 'directory') {
     mkdirSync(path.join(dir, RULE));
     writeFileSync(path.join(dir, RULE, SENTINEL_FILE), '');
+  } else {
+    mkdirSync(path.join(dir, NESTED_DIR, RULE), { recursive: true });
+    writeFileSync(path.join(dir, NESTED_DIR, RULE, SENTINEL_FILE), '');
   }
   return dir;
 };
 
-const withRuleSandbox = <T>(rule: string, shape: Shape, use: (dir: string) => T): T => {
-  const dir = makeRuleSandbox(rule, shape);
+const withRuleSandbox = <T>(rule: string, as: Materialisation, use: (dir: string) => T): T => {
+  const dir = makeRuleSandbox(rule, as);
   try {
     return use(dir);
   } finally {
@@ -195,33 +201,47 @@ const withRuleSandbox = <T>(rule: string, shape: Shape, use: (dir: string) => T)
   }
 };
 
-const RULE_MATRIX: Array<[string, boolean, boolean, boolean]> = [
-  [`/${RULE}`, true, true, true],
-  [`/${RULE}/`, false, true, true],
-  [`/${RULE}/**`, false, false, true],
-  [RULE, true, true, true],
-  [NEGATED, true, false, false],
+// [rule, symlink, directory, contents, nested] -- every value measured against real git.
+// The failure messages are RENDERED from this table (see shapeTable). They are not a second,
+// hand-written copy of it: that is what let six false claims ship while the suite stayed green.
+const RULE_MATRIX: Array<[string, boolean, boolean, boolean, boolean]> = [
+  [`/${RULE}`, true, true, true, false],
+  [`/${RULE}/`, false, true, true, false],
+  [`/${RULE}/**`, false, false, true, false],
+  [RULE, true, true, true, true],
+  [NEGATED, true, false, false, false],
 ];
+
+const asRuleFor = (rule: string, name: string) => rule.split(RULE).join(name).replace('\n', ' + ');
+const verb = (ignored: boolean) => (ignored ? 'ignores' : 'MISSES');
+
+const shapeTable = (name: string) =>
+  RULE_MATRIX.map(
+    ([rule, symlink, directory, contents, nested]) =>
+      `  "${asRuleFor(rule, name)}" -> ${verb(symlink)} the symlink, ${verb(directory)} the directory, ${verb(contents)} its contents, ${verb(nested)} a nested ${name}`,
+  ).join('\n');
 
 describe('meta: the rule-shape claims the failure messages make are true', () => {
   it.each(
     RULE_MATRIX,
-  )('rule %j -> symlink=%s directory=%s contents=%s', (rule, symlinkIgnored, directoryIgnored, contentsIgnored) => {
+  )('rule %j -> symlink=%s directory=%s contents=%s nested=%s', (rule, symlinkIgnored, directoryIgnored, contentsIgnored, nestedIgnored) => {
     const actual = {
       symlink: withRuleSandbox(rule, 'symlink', (dir) => isIgnored(dir, RULE)),
       directory: withRuleSandbox(rule, 'directory', (dir) => isIgnored(dir, RULE)),
       contents: withRuleSandbox(rule, 'directory', (dir) =>
         isIgnored(dir, `${RULE}/${SENTINEL_FILE}`),
       ),
+      nested: withRuleSandbox(rule, 'nested', (dir) => isIgnored(dir, `${NESTED_DIR}/${RULE}`)),
     };
 
     expect(
       actual,
-      `The failure messages in this file tell an engineer, as fact, what each rule shape does: that "/X/" misses the symlink, that "/X/**" misses the symlink AND the directory, that an unanchored "X" satisfies everything, and that a rule can be PRESENT and still lose to a negation. Those sentences are the only thing a reader gets when this gate reds, and no assertion held them -- which is exactly how six false claims shipped in them. This is the table that holds them now. If it fails, a message is lying, or git changed.`,
+      'RULE_MATRIX no longer matches what git does. This table is not documentation: the failure messages in this file are RENDERED from it, so an engineer reading a red test is reading these exact values. Six false claims shipped in those messages while the suite stayed green, precisely because the prose was a second, hand-written copy of this data. There is one copy now -- which means a wrong row here becomes a wrong sentence there. If this fails, either git changed, or a row was edited without measuring it.',
     ).toEqual({
       symlink: symlinkIgnored,
       directory: directoryIgnored,
       contents: contentsIgnored,
+      nested: nestedIgnored,
     });
   });
 

--- a/__tests__/meta/gitignore-worktree-symlinks.test.ts
+++ b/__tests__/meta/gitignore-worktree-symlinks.test.ts
@@ -142,7 +142,7 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
   it.each(HARNESS_SYMLINKS)('%s is ignored when materialised as a symlink', (name) => {
     expect(
       isIgnored(sandboxes.symlink, name),
-      `The harness symlinks "${name}" into every agent worktree, and this .gitignore does not ignore it.\n\nWrite "/${name}", with no trailing slash. A trailing slash makes a rule directory-only, and git lstats a path without following the link, so a symlink is not a directory and a directory-only rule cannot match it.\n\nEvery rule shape, measured against git (this table is rendered from the same data the matrix in this file asserts, so it cannot drift from what git actually does):\n\n${shapeTable(name)}\n\nOther harness paths asserted here: ${siblingsOf(name)}.\n\nThe child git sees exactly these variables: ${childEnvKeys()}. Only ${ENV_ALLOWLIST.join(' and ')} are inherited from the parent; the rest are set here. That allowlist is the whole defence, and it works by ABSENCE: GIT_DIR (a foreign info/exclude), HOME and XDG_CONFIG_HOME (a user ignore file), GIT_TEMPLATE_DIR (a seeded one) and the GIT_CONFIG_* family are each a SECOND place "${name}" could get ignored, and any one of them would turn this gate GREEN while the rule under test is broken. Measured: leak any one of them into the child and a broken rule reads as ignored.\n\nThe empty init template and core.excludesFile=${NULL_DEVICE} are backstops, not load-bearing -- measured: with the allowlist alone and both of those removed, a broken rule still reds. Do not "simplify" the allowlist on the grounds that the pins cover it. They do not; it is the other way round.`,
+      `The harness symlinks "${name}" into every agent worktree, and this .gitignore does not ignore it.\n\nWrite "/${name}", with no trailing slash. A trailing slash makes a rule directory-only, and git lstats a path without following the link, so a symlink is not a directory and a directory-only rule cannot match it.\n\nEvery rule shape, measured against git (this table is rendered from the same data the matrix in this file asserts, so it cannot drift from what git actually does):\n\n${shapeTable(name)}\n\nOther harness paths asserted here: ${siblingsOf(name)}.\n\nThe child git sees exactly these variables: ${childEnvKeys()}. Only ${ENV_ALLOWLIST.join(' and ')} are inherited from the parent; the rest are set here, alongside an empty init template and core.excludesFile=${NULL_DEVICE}. Every one of those exists to stop a SECOND ignore source reaching git -- a foreign GIT_DIR's info/exclude, a user or system ignore file, a seeded template. If one did, this gate could read GREEN while the rule under test is broken, which is the one outcome it exists to prevent. Which specific guard closes which specific channel is not asserted anywhere, so this message does not claim it: treat the sandbox as one indivisible thing and do not relax any part of it without gating what you removed.`,
     ).toBe(true);
   });
 
@@ -212,7 +212,8 @@ const RULE_MATRIX: Array<[string, boolean, boolean, boolean, boolean]> = [
   [NEGATED, true, false, false, false],
 ];
 
-const asRuleFor = (rule: string, name: string) => rule.split(RULE).join(name).replace('\n', ' + ');
+const asRuleFor = (rule: string, name: string) =>
+  rule.split(RULE).join(name).split('\n').join(' + ');
 const verb = (ignored: boolean) => (ignored ? 'ignores' : 'MISSES');
 
 const shapeTable = (name: string) =>

--- a/__tests__/meta/gitignore-worktree-symlinks.test.ts
+++ b/__tests__/meta/gitignore-worktree-symlinks.test.ts
@@ -61,7 +61,7 @@ const isIgnored = (cwd: string, target: string) => {
   const result = git(cwd, ['check-ignore', '-q', '--', target]);
   if (!gitAnswered(result)) {
     throw new Error(
-      `git check-ignore on "${target}" did not answer ${GIT_PATH_IGNORED} (ignored) or ${GIT_PATH_NOT_IGNORED} (not ignored): ${describeGitFailure(result)}. Nothing was learned about the .gitignore rule here, so do not go and edit it: reporting this as "not ignored" would red the assertion below and send you after a rule that may be fine.`,
+      `git check-ignore on "${target}" did not answer ${GIT_PATH_IGNORED} (ignored) or ${GIT_PATH_NOT_IGNORED} (not ignored): ${describeGitFailure(result)}. Nothing was learned about the .gitignore rule here, so do not go and edit it. This throws rather than returning a value because BOTH defaults are wrong: reported as "ignored" it would green a case that proves nothing, and reported as "not ignored" it would green the positive control, which expects exactly that.`,
     );
   }
   return result.status === GIT_PATH_IGNORED;
@@ -107,6 +107,7 @@ const siblingsOf = (name: string) => HARNESS_SYMLINKS.filter((other) => other !=
 const childEnvKeys = () => Object.keys(hermeticEnv()).sort().join(', ');
 
 const TRACKED_FILE = 'package.json';
+const SYMLINK_MODE = '120000';
 
 const gitResult = (over: Partial<GitResult>): GitResult => ({
   pid: 0,
@@ -162,6 +163,91 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
       isIgnored(sandboxes.symlink, TRACKED_FILE),
       `The sandbox reports "${TRACKED_FILE}" as ignored, which means it would report almost anything as ignored -- a .gitignore with a stray "*" does exactly that. Both cases above would then pass while proving nothing, because they only ever ask "is this path ignored?" and the answer had become yes for everything. This is the positive control: it is the assertion that keeps a green run meaningful.`,
     ).toBe(false);
+  });
+});
+
+const RULE = 'X';
+const NEGATED = `/${RULE}\n!/${RULE}/`;
+
+const makeRuleSandbox = (rule: string, shape: Shape) => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'gitignore-rule-'));
+  const init = git(dir, ['init', '-q', EMPTY_INIT_TEMPLATE]);
+  if (init.status !== GIT_OK) {
+    throw new Error(`git init failed in the rule sandbox: ${describeGitFailure(init)}.`);
+  }
+  writeFileSync(path.join(dir, '.gitignore'), `${rule}\n`);
+  if (shape === 'symlink') {
+    mkdirSync(path.join(dir, SYMLINK_TARGET));
+    symlinkSync(SYMLINK_TARGET, path.join(dir, RULE));
+  } else {
+    mkdirSync(path.join(dir, RULE));
+    writeFileSync(path.join(dir, RULE, SENTINEL_FILE), '');
+  }
+  return dir;
+};
+
+const withRuleSandbox = <T>(rule: string, shape: Shape, use: (dir: string) => T): T => {
+  const dir = makeRuleSandbox(rule, shape);
+  try {
+    return use(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+const RULE_MATRIX: Array<[string, boolean, boolean, boolean]> = [
+  [`/${RULE}`, true, true, true],
+  [`/${RULE}/`, false, true, true],
+  [`/${RULE}/**`, false, false, true],
+  [RULE, true, true, true],
+  [NEGATED, true, false, false],
+];
+
+describe('meta: the rule-shape claims the failure messages make are true', () => {
+  it.each(
+    RULE_MATRIX,
+  )('rule %j -> symlink=%s directory=%s contents=%s', (rule, symlinkIgnored, directoryIgnored, contentsIgnored) => {
+    const actual = {
+      symlink: withRuleSandbox(rule, 'symlink', (dir) => isIgnored(dir, RULE)),
+      directory: withRuleSandbox(rule, 'directory', (dir) => isIgnored(dir, RULE)),
+      contents: withRuleSandbox(rule, 'directory', (dir) =>
+        isIgnored(dir, `${RULE}/${SENTINEL_FILE}`),
+      ),
+    };
+
+    expect(
+      actual,
+      `The failure messages in this file tell an engineer, as fact, what each rule shape does: that "/X/" misses the symlink, that "/X/**" misses the symlink AND the directory, that an unanchored "X" satisfies everything, and that a rule can be PRESENT and still lose to a negation. Those sentences are the only thing a reader gets when this gate reds, and no assertion held them -- which is exactly how six false claims shipped in them. This is the table that holds them now. If it fails, a message is lying, or git changed.`,
+    ).toEqual({
+      symlink: symlinkIgnored,
+      directory: directoryIgnored,
+      contents: contentsIgnored,
+    });
+  });
+
+  it('a present rule can still lose to a negation, so "no rule matches" is the wrong diagnosis', () => {
+    const matchedBy = withRuleSandbox(NEGATED, 'directory', (dir) =>
+      String(git(dir, ['check-ignore', '-v', '--no-index', '--', RULE]).stdout),
+    );
+
+    expect(
+      matchedBy.includes(`!/${RULE}/`),
+      `Under "/${RULE}" followed by "!/${RULE}/", git must report the NEGATION as the matching line. The directory-case message tells the reader not to conclude the rule is missing, because a present rule can lose -- and this is the witness for that sentence. Got: ${JSON.stringify(matchedBy)}`,
+    ).toBe(true);
+  });
+
+  it('under "/X/**" the worktree symlink is stageable, which is why that shape is not harmless', () => {
+    const mode = withRuleSandbox(`/${RULE}/**`, 'symlink', (dir) => {
+      git(dir, ['add', '-A']);
+      return String(git(dir, ['ls-files', '-s', RULE]).stdout)
+        .trim()
+        .split(/\s+/)[0];
+    });
+
+    expect(
+      mode,
+      `Under "/${RULE}/**" the symlink is left unignored, so "git add" stages it as a symlink blob (mode 120000) holding an absolute path to one machine. The directory-case message says exactly that, and says the contents are still safe -- both halves have to be true, or the message is misdirecting whoever is reading it mid-failure. Got mode: ${JSON.stringify(mode)}`,
+    ).toBe(SYMLINK_MODE);
   });
 });
 

--- a/__tests__/meta/gitignore-worktree-symlinks.test.ts
+++ b/__tests__/meta/gitignore-worktree-symlinks.test.ts
@@ -36,14 +36,19 @@ const hermeticEnv = (): NodeJS.ProcessEnv => {
 const git = (cwd: string, args: string[]) =>
   spawnSync('git', [...NO_GLOBAL_EXCLUDES, ...args], { cwd, env: hermeticEnv() });
 
+const describeGitFailure = (result: ReturnType<typeof git>) =>
+  result.error !== undefined
+    ? `git could not be spawned at all: ${result.error.message}. The sandbox passes an allowlisted environment, so the usual cause is that git is not reachable via the allowlisted PATH.`
+    : `it exited ${result.status}: ${String(result.stderr).trim()}`;
+
 const isIgnored = (cwd: string, target: string) => {
-  const { status, stderr } = git(cwd, ['check-ignore', '-q', '--', target]);
-  if (status !== GIT_PATH_IGNORED && status !== GIT_PATH_NOT_IGNORED) {
+  const result = git(cwd, ['check-ignore', '-q', '--', target]);
+  if (result.status !== GIT_PATH_IGNORED && result.status !== GIT_PATH_NOT_IGNORED) {
     throw new Error(
-      `git check-ignore on "${target}" exited ${status}, which is neither ${GIT_PATH_IGNORED} (ignored) nor ${GIT_PATH_NOT_IGNORED} (not ignored): ${stderr}. Treating that as "not ignored" would red the assertion below and blame the .gitignore rule for what is actually a broken sandbox.`,
+      `git check-ignore on "${target}" answered neither ${GIT_PATH_IGNORED} (ignored) nor ${GIT_PATH_NOT_IGNORED} (not ignored): ${describeGitFailure(result)}. That is a broken sandbox, not a broken .gitignore rule. Reporting it as "not ignored" would red the assertion below and send you to edit a rule that is fine.`,
     );
   }
-  return status === GIT_PATH_IGNORED;
+  return result.status === GIT_PATH_IGNORED;
 };
 
 const sandboxes: Record<Shape, string> = { symlink: '', directory: '' };
@@ -55,7 +60,7 @@ const makeSandbox = (shape: Shape) => {
   const init = git(dir, ['init', '-q', EMPTY_INIT_TEMPLATE]);
   if (init.status !== GIT_OK) {
     throw new Error(
-      `git init failed in the ${shape} sandbox (exit ${init.status}): ${init.stderr}. Every case below would then red for that reason while blaming the .gitignore rule.`,
+      `git init failed in the ${shape} sandbox: ${describeGitFailure(init)}. Every case below would then red for that reason while blaming the .gitignore rule.`,
     );
   }
 

--- a/__tests__/meta/gitignore-worktree-symlinks.test.ts
+++ b/__tests__/meta/gitignore-worktree-symlinks.test.ts
@@ -36,16 +36,27 @@ const hermeticEnv = (): NodeJS.ProcessEnv => {
 const git = (cwd: string, args: string[]) =>
   spawnSync('git', [...NO_GLOBAL_EXCLUDES, ...args], { cwd, env: hermeticEnv() });
 
-const describeGitFailure = (result: ReturnType<typeof git>) =>
-  result.error !== undefined
-    ? `git could not be spawned at all: ${result.error.message}. The sandbox passes an allowlisted environment, so the usual cause is that git is not reachable via the allowlisted PATH.`
-    : `it exited ${result.status}: ${String(result.stderr).trim()}`;
+const NOT_FOUND = 'ENOENT';
+
+const describeGitFailure = (result: ReturnType<typeof git>) => {
+  if (result.error === undefined) {
+    return `it exited ${result.status}: ${String(result.stderr).trim()}`;
+  }
+  const spawned = `git could not be spawned at all: ${result.error.message}`;
+  return result.error.message.includes(NOT_FOUND)
+    ? `${spawned}. This sandbox gives the child an allowlisted environment (${ENV_ALLOWLIST.join(', ')}), so git is not reachable via that PATH.`
+    : spawned;
+};
+
+const gitAnswered = (result: ReturnType<typeof git>) =>
+  result.error === undefined &&
+  (result.status === GIT_PATH_IGNORED || result.status === GIT_PATH_NOT_IGNORED);
 
 const isIgnored = (cwd: string, target: string) => {
   const result = git(cwd, ['check-ignore', '-q', '--', target]);
-  if (result.status !== GIT_PATH_IGNORED && result.status !== GIT_PATH_NOT_IGNORED) {
+  if (!gitAnswered(result)) {
     throw new Error(
-      `git check-ignore on "${target}" answered neither ${GIT_PATH_IGNORED} (ignored) nor ${GIT_PATH_NOT_IGNORED} (not ignored): ${describeGitFailure(result)}. That is a broken sandbox, not a broken .gitignore rule. Reporting it as "not ignored" would red the assertion below and send you to edit a rule that is fine.`,
+      `git check-ignore on "${target}" answered neither ${GIT_PATH_IGNORED} (ignored) nor ${GIT_PATH_NOT_IGNORED} (not ignored): ${describeGitFailure(result)}. git did not answer the question, so this is not a verdict on the .gitignore rule. Reporting it as "not ignored" would red the assertion below and send you to edit a rule that may be fine.`,
     );
   }
   return result.status === GIT_PATH_IGNORED;
@@ -94,7 +105,7 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
   it.each(HARNESS_SYMLINKS)('%s is ignored when materialised as a symlink', (name) => {
     expect(
       isIgnored(sandboxes.symlink, name),
-      `The harness symlinks "${name}" into every agent worktree, and this .gitignore does not ignore it.\n\nWrite "/${name}": root-anchored, no trailing slash. A trailing slash makes a rule directory-only, and git lstats a path without following the link, so "/${name}/" cannot match a symlink. The slashless form matches the symlink, the real directory, and the directory's contents -- the sibling case in this file asserts those last two, so check it before widening this rule.\n\nOther harness paths asserted here: ${siblingsOf(name)}.\n\nThe sandbox runs git on an allowlisted environment (${childEnvKeys()}), with an empty init template and core.excludesFile pinned to ${NULL_DEVICE}. That is not incidental: any ambient ignore source -- a foreign GIT_DIR's info/exclude, a seeded template, a user or system ignore file -- would be a SECOND place the path could get ignored, and this gate would then read GREEN while the rule under test is broken. If you relax the sandbox, this test can start passing for a reason that has nothing to do with .gitignore.`,
+      `The harness symlinks "${name}" into every agent worktree, and this .gitignore does not ignore it.\n\nWrite "/${name}", with no trailing slash. A trailing slash makes a rule directory-only, and git lstats a path without following the link, so a symlink is not a directory and "/${name}/" cannot match it. Measured: "/${name}" matches the symlink, the real directory, and the directory's contents; "/${name}/" misses the symlink; "/${name}/**" misses the symlink and the directory. The sibling case in this file asserts the directory and its contents, so read it before widening this rule.\n\nOther harness paths asserted here: ${siblingsOf(name)}.\n\nThe child git sees exactly these variables: ${childEnvKeys()}. Only ${ENV_ALLOWLIST.join(' and ')} are inherited; the rest are injected here, alongside an empty init template and core.excludesFile=${NULL_DEVICE}. That is deliberate. An ambient ignore source -- a foreign GIT_DIR's info/exclude, a seeded template, a user or system ignore file -- is a SECOND place "${name}" could get ignored, and this gate would then read GREEN while the rule under test is broken. Relax the sandbox and this test can start passing for a reason that has nothing to do with .gitignore.`,
     ).toBe(true);
   });
 
@@ -106,7 +117,7 @@ describe('meta: .gitignore covers the paths the agent-worktree harness symlinks'
 
     expect(
       directoryIgnored && contentsIgnored,
-      `The rule for "${name}" must keep ignoring the REAL ${name} directory and everything inside it. Measured here: directory ignored = ${directoryIgnored}, contents ignored = ${contentsIgnored}.\n\nIn the main tree ${name} is a real directory, not the symlink the sibling case covers. If this regresses, its contents become committable — build output in the case of .next, the entire dependency tree in the case of node_modules. That is a far worse outcome than the phantom untracked symlink, and it is the direction a well-meaning edit to the symlink case can silently break, so it is asserted rather than assumed.\n\nRoot-anchored and slashless ("/${name}") is the form that satisfies every case in this file: a directory-only "/${name}/" misses the symlink, "/${name}/**" would match the contents but not the directory itself, and an unanchored "${name}" would satisfy all of them but also match at every depth, which is wider than intended.`,
+      `The rule for "${name}" must keep ignoring the REAL ${name} directory and everything inside it. In the main tree ${name} is a real directory, not the symlink the sibling case covers. Measured here: directory ignored = ${directoryIgnored}, contents ignored = ${contentsIgnored}.\n\nIf BOTH are false, no rule matches ${name} at all and everything inside it becomes committable. That is the outcome this case exists to prevent, and it is the direction a well-meaning edit to the symlink case can silently break.\n\nIf only the directory is false, the rule matches below ${name} but not ${name} itself -- the "/${name}/**" shape. Nothing becomes committable then, because the contents are still ignored. But that shape does not match a symlink either, so the sibling case above is red too, and that is the one to fix.\n\nMeasured forms: "/${name}" satisfies this case and the symlink case; "/${name}/" misses the symlink; "/${name}/**" misses the symlink and this directory. An unanchored "${name}" satisfies all of them as well -- so nothing in this file holds the leading "/". The anchor is there to stop the rule matching a nested ${name} at any depth, and no test here asserts that.`,
     ).toBe(true);
   });
 });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "start": "next start",
     "check": "biome check .",
     "check:fix": "biome check --write .",
+    "gitleaks:staged": "node scripts/gitleaks-staged.mjs",
+    "gitleaks:fixture": "node scripts/check-gitleaks-fixture.mjs",
     "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/scripts/__tests__/check-gitleaks-fixture.test.ts
+++ b/scripts/__tests__/check-gitleaks-fixture.test.ts
@@ -87,6 +87,14 @@ describe('assertConfigShape (the config cannot be quietly gutted)', () => {
     ).toBe(false);
   });
 
+  it('rejects an INLINE-TABLE `paths` allowlist, which is valid TOML and a working bypass', () => {
+    const inlineTable = `title = "x"\nallowlists = [\n  { description = "y", paths = ['''.*sanitize-secrets.*'''] },\n]\n[extend]\nuseDefault = true\n`;
+    expect(
+      shape(inlineTable).ok,
+      `A line-anchored check only sees the block form. gitleaks 8.30 honours the inline-table form too, and it was a WORKING exploit: config accepted, probe green, and a real ghp_ token in the named file suppressed entirely -- 0 findings, exit 0, "clean". The probe cannot catch it either, because the probe writes its token to a temp dir that no repo-path regex matches. Both defences missed.`,
+    ).toBe(false);
+  });
+
   it('rejects disabled rules, which the probe cannot see', () => {
     expect(
       shape(`${REAL_CONFIG}\ndisabledRules = ["anthropic-api-key"]\n`).ok,

--- a/scripts/__tests__/check-gitleaks-fixture.test.ts
+++ b/scripts/__tests__/check-gitleaks-fixture.test.ts
@@ -1,11 +1,18 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  assertConfigShape,
   assertExpectedFindings,
   CLEAN_FIXTURE,
   EXPECTED_RULES,
   interpretGitleaksRun,
   LEAKY_FIXTURE,
 } from '../check-gitleaks-fixture.mjs';
+
+const REAL_CONFIG = readFileSync(path.resolve(__dirname, '..', '..', '.gitleaks.toml'), 'utf-8');
+const NO_IGNORE_FILE = false;
+const NO_ALLOW_COMMENTS: string[] = [];
 
 const NO_LEAKS = 0;
 const LEAKS_FOUND = 1;
@@ -30,21 +37,72 @@ describe('interpretGitleaksRun (the gate cannot read clean unless gitleaks reall
     ).toBe(false);
   });
 
-  it('gitleaks failing to spawn is a FAILURE', () => {
+  it('gitleaks failing to spawn is a FAILURE, and the reason names the cause', () => {
+    const verdict = run({ error: new Error('spawnSync gitleaks ENOENT'), status: null });
+    expect(verdict.ok, FAIL_CLOSED).toBe(false);
     expect(
-      run({ error: new Error('spawnSync gitleaks ENOENT'), status: null }).ok,
-      FAIL_CLOSED,
-    ).toBe(false);
+      verdict.reason,
+      'The reason is the only thing anyone reads when this reds in CI. Asserting only `ok` lets the did-not-run branch be deleted silently: the result then falls through to the unknown-exit-code branch, which is also ok:false, so no test notices — while the message degrades to "exited null", which names nothing.',
+    ).toContain('ENOENT');
   });
 
-  it('gitleaks killed by a signal is a FAILURE', () => {
-    expect(run({ status: null }).ok, FAIL_CLOSED).toBe(false);
+  it('gitleaks killed by a signal is a FAILURE, and the reason does not just say null', () => {
+    const verdict = run({ status: null });
+    expect(verdict.ok, FAIL_CLOSED).toBe(false);
+    expect(
+      verdict.reason,
+      'spawnSync reports status=null for BOTH a missing binary and a signal-killed child. A reason that renders "null" has told the reader nothing about which one happened.',
+    ).not.toContain('null');
   });
 
   it('an unknown exit code is a FAILURE, never silently treated as clean', () => {
     expect(
       run({ status: FATAL, stderr: 'fatal: config is invalid' }).ok,
       `${FAIL_CLOSED}\n\nExit ${FATAL} is neither ${NO_LEAKS} (clean) nor ${LEAKS_FOUND} (leaks found). A malformed .gitleaks.toml exits non-zero, and mapping that onto "clean" is exactly how a broken gate goes green.`,
+    ).toBe(false);
+  });
+});
+
+describe('assertConfigShape (the config cannot be quietly gutted)', () => {
+  const shape = (config: string, ignoreFile = NO_IGNORE_FILE, comments = NO_ALLOW_COMMENTS) =>
+    assertConfigShape(config, ignoreFile, comments);
+
+  it('the repo config as committed is accepted', () => {
+    expect(
+      shape(REAL_CONFIG).ok,
+      '.gitleaks.toml itself violates the shape this gate requires.',
+    ).toBe(true);
+  });
+
+  it('rejects a `paths` allowlist, because it exempts the file from EVERY rule', () => {
+    expect(
+      shape(`${REAL_CONFIG}\n[[allowlists]]\npaths = ['''.*''']\n`).ok,
+      `Measured on gitleaks 8.30: a "paths" entry exempts that file from every rule, making it a permanent secret-laundering path. Three files in this repo were exempt from everything — including a test suite full of real-shaped tokens — and the probe could not see it, because the probe scans a token in a temp dir that no repo path regex matches. This is the assertion that catches it.`,
+    ).toBe(false);
+  });
+
+  it('rejects disabled rules, which the probe cannot see', () => {
+    expect(
+      shape(`${REAL_CONFIG}\ndisabledRules = ["anthropic-api-key"]\n`).ok,
+      'The probe only proves ONE rule still fires. Disabling every OTHER class leaves the probe green while the scanner is dead for the credentials this repo actually holds.',
+    ).toBe(false);
+  });
+
+  it('rejects a config that drops the default ruleset', () => {
+    expect(shape(REAL_CONFIG.replace('useDefault = true', 'useDefault = false')).ok).toBe(false);
+  });
+
+  it('rejects a .gitleaksignore file', () => {
+    expect(
+      shape(REAL_CONFIG, true).ok,
+      'gitleaks silently skips every fingerprint listed in .gitleaksignore, and nothing else in this gate would notice.',
+    ).toBe(false);
+  });
+
+  it('rejects a gitleaks:allow suppression comment in the tree', () => {
+    expect(
+      shape(REAL_CONFIG, NO_IGNORE_FILE, ['lib/somewhere.ts']).ok,
+      'That comment makes gitleaks skip the line, with no record of why. It is the cheapest way to make this whole gate lie, and it is the first thing a blocked developer reaches for.',
     ).toBe(false);
   });
 });

--- a/scripts/__tests__/check-gitleaks-fixture.test.ts
+++ b/scripts/__tests__/check-gitleaks-fixture.test.ts
@@ -95,6 +95,16 @@ describe('assertConfigShape (the config cannot be quietly gutted)', () => {
     ).toBe(false);
   });
 
+  it.each([
+    ['quoted key', "\"paths\" = ['''.*''']"],
+    ['dotted key', "allowlist.paths = ['''.*''']"],
+  ])('rejects a %s `paths` allowlist -- valid TOML gitleaks honours, same laundering path', (_label, line) => {
+    expect(
+      shape(`useDefault = true\n${line}\n`).ok,
+      'gitleaks treats a quoted or dotted key as equivalent to the bare key, so "paths" = / allowlist.paths = exempt the file exactly as `paths =` does. A line-anchored bare-key check misses them, and a path-scoped variant evades the probe too. The durable fix is to parse the TOML (task #25); this closes the common spellings.',
+    ).toBe(false);
+  });
+
   it('rejects disabled rules, which the probe cannot see', () => {
     expect(
       shape(`${REAL_CONFIG}\ndisabledRules = ["anthropic-api-key"]\n`).ok,

--- a/scripts/__tests__/check-gitleaks-fixture.test.ts
+++ b/scripts/__tests__/check-gitleaks-fixture.test.ts
@@ -105,10 +105,14 @@ describe('assertConfigShape (the config cannot be quietly gutted)', () => {
     ).toBe(false);
   });
 
-  it('rejects disabled rules, which the probe cannot see', () => {
+  it.each([
+    ['bare', 'disabledRules = ["anthropic-api-key"]'],
+    ['quoted key', '"disabledRules" = ["anthropic-api-key"]'],
+    ['dotted key', 'extend.disabledRules = ["anthropic-api-key"]'],
+  ])('rejects %s disabled rules, which the probe cannot see', (_label, line) => {
     expect(
-      shape(`${REAL_CONFIG}\ndisabledRules = ["anthropic-api-key"]\n`).ok,
-      'The probe only proves ONE rule still fires. Disabling every OTHER class leaves the probe green while the scanner is dead for the credentials this repo actually holds.',
+      shape(`useDefault = true\n${line}\n`).ok,
+      'The probe only proves ONE rule still fires. Disabling every OTHER class leaves the probe green while the scanner is dead for the credentials this repo actually holds. gitleaks treats quoted and dotted keys as equivalent to the bare key, so all three spellings must be rejected -- and the `paths` ban gets the same broadening, so this holds it too.',
     ).toBe(false);
   });
 

--- a/scripts/__tests__/check-gitleaks-fixture.test.ts
+++ b/scripts/__tests__/check-gitleaks-fixture.test.ts
@@ -14,6 +14,12 @@ const REAL_CONFIG = readFileSync(path.resolve(__dirname, '..', '..', '.gitleaks.
 const NO_IGNORE_FILE = false;
 const NO_ALLOW_COMMENTS: string[] = [];
 
+// Assembled, never spelled out: the gate greps the tree for this literal, so a test file that
+// names it reds the gate on itself. That is not hypothetical -- it happened, and CI caught it
+// before these unit tests did, because they call assertConfigShape with synthetic arguments and
+// never exercise the real tree scan.
+const SUPPRESSION_COMMENT = ['gitleaks', 'allow'].join(':');
+
 const NO_LEAKS = 0;
 const LEAKS_FOUND = 1;
 const FATAL = 2;
@@ -99,10 +105,10 @@ describe('assertConfigShape (the config cannot be quietly gutted)', () => {
     ).toBe(false);
   });
 
-  it('rejects a gitleaks:allow suppression comment in the tree', () => {
+  it('rejects a suppression comment in the tree', () => {
     expect(
       shape(REAL_CONFIG, NO_IGNORE_FILE, ['lib/somewhere.ts']).ok,
-      'That comment makes gitleaks skip the line, with no record of why. It is the cheapest way to make this whole gate lie, and it is the first thing a blocked developer reaches for.',
+      `The ${SUPPRESSION_COMMENT} comment makes gitleaks skip the line, with no record of why. It is the cheapest way to make this whole gate lie, and it is the first thing a blocked developer reaches for.\n\nNote this test does not spell that comment out literally: the gate greps the tree for it, and a test file naming it would red the gate on itself — which is exactly what happened, and what the CI job caught before the unit tests did.`,
     ).toBe(false);
   });
 });

--- a/scripts/__tests__/check-gitleaks-fixture.test.ts
+++ b/scripts/__tests__/check-gitleaks-fixture.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertExpectedFindings,
+  CLEAN_FIXTURE,
+  EXPECTED_RULES,
+  interpretGitleaksRun,
+  LEAKY_FIXTURE,
+} from '../check-gitleaks-fixture.mjs';
+
+const NO_LEAKS = 0;
+const LEAKS_FOUND = 1;
+const FATAL = 2;
+
+const run = (over: Partial<Parameters<typeof interpretGitleaksRun>[0]>) =>
+  interpretGitleaksRun({ status: LEAKS_FOUND, stderr: '', ...over });
+
+const FAIL_CLOSED =
+  'This is the whole fail-closed defence of the secret gate. If any of these branches returns ok:true, CI reports "no secrets" for a scan that never happened, or never fired — which reads identically to a clean tree and is the one failure this job exists to make impossible.';
+
+describe('interpretGitleaksRun (the gate cannot read clean unless gitleaks really scanned)', () => {
+  it('a scanner that found the planted secret is the only accepted outcome', () => {
+    expect(run({ status: LEAKS_FOUND }).ok).toBe(true);
+  });
+
+  it('gitleaks finding NOTHING in the bait fixture is a FAILURE, not a pass', () => {
+    const verdict = run({ status: NO_LEAKS });
+    expect(
+      verdict.ok,
+      `${FAIL_CLOSED}\n\nExit ${NO_LEAKS} here means gitleaks ran and saw nothing in a file that plants a real ${EXPECTED_RULES.join(', ')} token. The scanner is not firing, so a green scan of the real tree proves nothing.`,
+    ).toBe(false);
+  });
+
+  it('gitleaks failing to spawn is a FAILURE', () => {
+    expect(
+      run({ error: new Error('spawnSync gitleaks ENOENT'), status: null }).ok,
+      FAIL_CLOSED,
+    ).toBe(false);
+  });
+
+  it('gitleaks killed by a signal is a FAILURE', () => {
+    expect(run({ status: null }).ok, FAIL_CLOSED).toBe(false);
+  });
+
+  it('an unknown exit code is a FAILURE, never silently treated as clean', () => {
+    expect(
+      run({ status: FATAL, stderr: 'fatal: config is invalid' }).ok,
+      `${FAIL_CLOSED}\n\nExit ${FATAL} is neither ${NO_LEAKS} (clean) nor ${LEAKS_FOUND} (leaks found). A malformed .gitleaks.toml exits non-zero, and mapping that onto "clean" is exactly how a broken gate goes green.`,
+    ).toBe(false);
+  });
+});
+
+describe('assertExpectedFindings (the bait must fire, the clean fixture must not)', () => {
+  const leaky = EXPECTED_RULES.map((RuleID) => ({ File: `/tmp/x/${LEAKY_FIXTURE}`, RuleID }));
+  const ANY_EXPECTED_RULE = EXPECTED_RULES[0] ?? '';
+
+  it('accepts the expected rule firing on the leaky fixture and nothing on the clean one', () => {
+    expect(assertExpectedFindings(leaky).ok).toBe(true);
+  });
+
+  it('rejects an empty finding set', () => {
+    expect(assertExpectedFindings([]).ok).toBe(false);
+  });
+
+  it('rejects the expected rule not firing on the leaky fixture', () => {
+    expect(
+      assertExpectedFindings([{ File: `/tmp/x/${LEAKY_FIXTURE}`, RuleID: 'some-other-rule' }]).ok,
+      'If the rule named in EXPECTED_RULES stops firing -- renamed upstream, dropped from the default set, or the planted token no longer matches it -- the real scan silently stops covering that class of secret. This is what notices.',
+    ).toBe(false);
+  });
+
+  it('rejects any finding on the clean fixture', () => {
+    expect(
+      assertExpectedFindings([
+        ...leaky,
+        { File: `/tmp/x/${CLEAN_FIXTURE}`, RuleID: ANY_EXPECTED_RULE },
+      ]).ok,
+      'A scanner that fires on code with no secret in it trains people to ignore it, and an ignored gate is a disabled gate.',
+    ).toBe(false);
+  });
+});

--- a/scripts/__tests__/check-gitleaks-fixture.test.ts
+++ b/scripts/__tests__/check-gitleaks-fixture.test.ts
@@ -8,6 +8,7 @@ import {
   EXPECTED_RULES,
   interpretGitleaksRun,
   LEAKY_FIXTURE,
+  mayNameTheComment,
 } from '../check-gitleaks-fixture.mjs';
 
 const REAL_CONFIG = readFileSync(path.resolve(__dirname, '..', '..', '.gitleaks.toml'), 'utf-8');
@@ -161,6 +162,28 @@ describe('assertExpectedFindings (the bait must fire, the clean fixture must not
         { File: `/tmp/x/${CLEAN_FIXTURE}`, RuleID: ANY_EXPECTED_RULE },
       ]).ok,
       'A scanner that fires on code with no secret in it trains people to ignore it, and an ignored gate is a disabled gate.',
+    ).toBe(false);
+  });
+});
+
+describe('mayNameTheComment (only the machinery may spell the banned phrase, exactly)', () => {
+  it.each([
+    'scripts/check-gitleaks-fixture.mjs',
+    'scripts/gitleaks-staged.mjs',
+    'docs/superpowers/plans/2026-06-19-static-analysis-semgrep-plan.md',
+  ])('%s is allowed to name the phrase', (file) => {
+    expect(mayNameTheComment(file)).toBe(true);
+  });
+
+  it.each([
+    'scripts/gitleaks-staged.mjs.bak',
+    'scripts/gitleaks-staged.mjs~',
+    'scripts/check-gitleaks-fixture.mjs.orig',
+    'lib/somewhere.ts',
+  ])('%s is NOT allowed -- a prefix must not re-exempt a suffixed or unrelated file', (file) => {
+    expect(
+      mayNameTheComment(file),
+      `The two source files are matched EXACTLY. A startsWith prefix would let a committed backup (.bak/.orig/~) carry the ${SUPPRESSION_COMMENT} suppression comment past this gate -- the same "a prefix exempts more than intended" bypass this PR closed for .gitleaks.toml. Only the docs directory is a genuine prefix.`,
     ).toBe(false);
   });
 });

--- a/scripts/__tests__/gitleaks-staged.test.ts
+++ b/scripts/__tests__/gitleaks-staged.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { decideStagedExit, LEAKS_FOUND, NO_LEAKS } from '../gitleaks-staged.mjs';
+
+const FATAL = 2;
+
+const FAIL_CLOSED =
+  'This runs on EVERY commit and is the only thing standing between a secret and git history. Once a secret is committed and pushed it is published, and rotation is the only remedy — so a branch here that lets the commit through is not a bug, it is the leak.';
+
+describe('decideStagedExit (the pre-commit gate cannot let a commit through unless gitleaks really scanned)', () => {
+  it('a clean staged tree is the ONLY case that lets the commit through', () => {
+    expect(decideStagedExit({ status: NO_LEAKS }).block).toBe(false);
+  });
+
+  it('a secret in the staged changes blocks the commit', () => {
+    const verdict = decideStagedExit({ status: LEAKS_FOUND });
+    expect(verdict.block, FAIL_CLOSED).toBe(true);
+    expect(verdict.reason).toContain('the commit is blocked');
+  });
+
+  it('a missing gitleaks binary BLOCKS, and says how to install it', () => {
+    const verdict = decideStagedExit({
+      error: new Error('spawnSync gitleaks ENOENT'),
+      status: null,
+    });
+    expect(
+      verdict.block,
+      `${FAIL_CLOSED}\n\nA scanner that silently skips when it is not installed is the same as no scanner, and nobody would ever find out — which is precisely the state this repo was in before this gate existed.`,
+    ).toBe(true);
+    expect(verdict.reason).toContain('brew install gitleaks');
+    expect(verdict.reason).toContain('ENOENT');
+  });
+
+  it('gitleaks killed by a signal BLOCKS', () => {
+    expect(decideStagedExit({ status: null }).block, FAIL_CLOSED).toBe(true);
+  });
+
+  it('an unknown exit code BLOCKS, never reads as clean', () => {
+    const verdict = decideStagedExit({ status: FATAL });
+    expect(
+      verdict.block,
+      `${FAIL_CLOSED}\n\nA malformed .gitleaks.toml exits non-zero. Mapping that onto "clean" would mean a broken config silently disables the local gate.`,
+    ).toBe(true);
+    expect(verdict.reason).toContain(String(FATAL));
+  });
+
+  it('the false-positive guidance does not tell the developer to use a paths allowlist', () => {
+    const verdict = decideStagedExit({ status: LEAKS_FOUND });
+    expect(
+      verdict.reason,
+      'This message is read at the exact moment a developer decides HOW to allowlist. It previously told them to add a `paths` entry — which exempts that file from EVERY rule and makes it a permanent secret-laundering path. The hook was instructing them to recreate the vulnerability.',
+    ).toContain('Never a `paths` entry');
+  });
+});

--- a/scripts/__tests__/gitleaks-staged.test.ts
+++ b/scripts/__tests__/gitleaks-staged.test.ts
@@ -41,13 +41,18 @@ describe('decideStagedExit (the pre-commit gate cannot let a commit through unle
     expect(verdict.reason).toContain('ENOENT');
   });
 
-  it('gitleaks killed by a signal BLOCKS, and still says how to install it', () => {
+  it('gitleaks killed by a signal BLOCKS, and the reason names the kill -- not a missing binary', () => {
     const verdict = decideStagedExit({ status: null });
     expect(verdict.block, FAIL_CLOSED).toBe(true);
     expect(
       verdict.reason,
-      'Asserting only `block` lets the did-not-run branch be deleted: the result falls through to the unknown-exit-code branch, which also blocks, so no test notices — while the message degrades from "brew install gitleaks" to "exited null".',
-    ).toContain('brew install gitleaks');
+      'Asserting only `block` lets the did-not-run branch be deleted: the result falls through to the unknown-exit-code branch, which also blocks, so no test notices — while the message degrades to "exited null", which names nothing.',
+    ).toContain('killed');
+    expect(
+      verdict.reason,
+      'A killed scanner is not a missing one. Telling the developer to `brew install gitleaks` when the binary is installed and was OOM-killed sends them to fix the wrong thing — the same message-contradiction class this PR keeps closing.',
+    ).not.toContain('brew install');
+    expect(verdict.reason).not.toContain('null');
   });
 
   it('an unknown exit code BLOCKS, never reads as clean', () => {

--- a/scripts/__tests__/gitleaks-staged.test.ts
+++ b/scripts/__tests__/gitleaks-staged.test.ts
@@ -7,14 +7,25 @@ const FAIL_CLOSED =
   'This runs on EVERY commit and is the only thing standing between a secret and git history. Once a secret is committed and pushed it is published, and rotation is the only remedy — so a branch here that lets the commit through is not a bug, it is the leak.';
 
 describe('decideStagedExit (the pre-commit gate cannot let a commit through unless gitleaks really scanned)', () => {
-  it('a clean staged tree is the ONLY case that lets the commit through', () => {
-    expect(decideStagedExit({ status: NO_LEAKS }).block).toBe(false);
+  // The literals, not the constants. Feeding NO_LEAKS/LEAKS_FOUND back in would make these
+  // tautological: swap the two constants and every test still passes, while in production
+  // gitleaks' real exit 1 ("secret found") would read as clean and the commit would ship the
+  // secret. The exit codes are a claim about an EXTERNAL tool, so a test that consumes the
+  // claim cannot verify it. (Test files are exempt from the no-magic-values rule, and here the
+  // literal IS the point.)
+  it('gitleaks exit 0 -- and only exit 0 -- lets the commit through', () => {
+    expect(decideStagedExit({ status: 0 }).block, FAIL_CLOSED).toBe(false);
+    expect(NO_LEAKS, 'NO_LEAKS must be the exit code gitleaks returns for a clean tree').toBe(0);
   });
 
-  it('a secret in the staged changes blocks the commit', () => {
-    const verdict = decideStagedExit({ status: LEAKS_FOUND });
+  it('gitleaks exit 1 (a secret in the staged changes) blocks the commit', () => {
+    const verdict = decideStagedExit({ status: 1 });
     expect(verdict.block, FAIL_CLOSED).toBe(true);
     expect(verdict.reason).toContain('the commit is blocked');
+    expect(
+      LEAKS_FOUND,
+      'LEAKS_FOUND must be the exit code gitleaks returns when it finds a secret. If this constant drifts, a real finding is read as clean and the commit ships the secret.',
+    ).toBe(1);
   });
 
   it('a missing gitleaks binary BLOCKS, and says how to install it', () => {
@@ -30,8 +41,13 @@ describe('decideStagedExit (the pre-commit gate cannot let a commit through unle
     expect(verdict.reason).toContain('ENOENT');
   });
 
-  it('gitleaks killed by a signal BLOCKS', () => {
-    expect(decideStagedExit({ status: null }).block, FAIL_CLOSED).toBe(true);
+  it('gitleaks killed by a signal BLOCKS, and still says how to install it', () => {
+    const verdict = decideStagedExit({ status: null });
+    expect(verdict.block, FAIL_CLOSED).toBe(true);
+    expect(
+      verdict.reason,
+      'Asserting only `block` lets the did-not-run branch be deleted: the result falls through to the unknown-exit-code branch, which also blocks, so no test notices — while the message degrades from "brew install gitleaks" to "exited null".',
+    ).toContain('brew install gitleaks');
   });
 
   it('an unknown exit code BLOCKS, never reads as clean', () => {

--- a/scripts/check-gitleaks-fixture.d.mts
+++ b/scripts/check-gitleaks-fixture.d.mts
@@ -1,0 +1,22 @@
+export declare const EXPECTED_RULES: string[];
+export declare const LEAKY_FIXTURE: string;
+export declare const CLEAN_FIXTURE: string;
+
+export interface Verdict {
+  ok: boolean;
+  reason?: string;
+}
+
+export interface GitleaksRun {
+  error?: Error;
+  status: number | null;
+  stderr?: string | Buffer | null;
+}
+
+export interface GitleaksFinding {
+  File?: string;
+  RuleID?: string;
+}
+
+export declare function interpretGitleaksRun(res: GitleaksRun): Verdict;
+export declare function assertExpectedFindings(findings: GitleaksFinding[]): Verdict;

--- a/scripts/check-gitleaks-fixture.d.mts
+++ b/scripts/check-gitleaks-fixture.d.mts
@@ -26,3 +26,5 @@ export declare function assertConfigShape(
   hasIgnoreFile: boolean,
   allowComments: string[],
 ): Verdict;
+
+export declare function mayNameTheComment(file: string): boolean;

--- a/scripts/check-gitleaks-fixture.d.mts
+++ b/scripts/check-gitleaks-fixture.d.mts
@@ -20,3 +20,9 @@ export interface GitleaksFinding {
 
 export declare function interpretGitleaksRun(res: GitleaksRun): Verdict;
 export declare function assertExpectedFindings(findings: GitleaksFinding[]): Verdict;
+
+export declare function assertConfigShape(
+  config: string,
+  hasIgnoreFile: boolean,
+  allowComments: string[],
+): Verdict;

--- a/scripts/check-gitleaks-fixture.mjs
+++ b/scripts/check-gitleaks-fixture.mjs
@@ -42,14 +42,14 @@ export function assertConfigShape(config, hasIgnoreFile, allowComments) {
         'the gitleaks config does not set `useDefault = true`. Without the default ruleset there is almost nothing left to detect, and the probe below would still pass on whatever remains.',
     };
   }
-  if (/^\s*disabledRules\s*=\s*\[\s*[^\]\s]/m.test(config)) {
+  if (/(?:^|[{,])\s*disabledRules\s*=\s*\[\s*[^\]\s]/m.test(config)) {
     return {
       ok: false,
       reason:
         'the gitleaks config disables rules. Disabling a rule class is invisible to the probe below, which only proves that ONE rule still fires. If a rule genuinely false-positives, allowlist the offending VALUE with a `regexes` entry instead.',
     };
   }
-  if (/^\s*paths\s*=/m.test(config)) {
+  if (/(?:^|[{,])\s*paths\s*=/m.test(config)) {
     return {
       ok: false,
       reason:
@@ -155,10 +155,21 @@ const MAY_NAME_THE_COMMENT = [
   'docs/superpowers/plans/',
 ];
 
+const GREP_MATCHED = 0;
+const GREP_NO_MATCH = 1;
+
 function trackedFilesContaining(needle) {
   const listed = spawnSync('git', ['grep', '-l', '--fixed-strings', needle, '--', '.'], {
     encoding: 'utf8',
   });
+  // git grep exits 1 for "no match" and >=2 for an error, and BOTH produce empty stdout. Reading
+  // stdout alone makes a broken git indistinguishable from a clean tree -- the same fail-open
+  // this file exists to forbid, in the function that enforces the ban.
+  if (listed.status !== GREP_MATCHED && listed.status !== GREP_NO_MATCH) {
+    throw new Error(
+      `git grep could not scan the tree for suppression comments (exit ${listed.status}): ${String(listed.stderr ?? listed.error?.message).trim()}. Empty output from a FAILED grep looks exactly like a clean tree, so this refuses rather than reporting one.`,
+    );
+  }
   return String(listed.stdout ?? '')
     .split('\n')
     .filter((file) => file !== '')
@@ -242,4 +253,9 @@ function main() {
   }
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) main();
+if (
+  typeof process.argv[1] === 'string' &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/check-gitleaks-fixture.mjs
+++ b/scripts/check-gitleaks-fixture.mjs
@@ -42,14 +42,14 @@ export function assertConfigShape(config, hasIgnoreFile, allowComments) {
         'the gitleaks config does not set `useDefault = true`. Without the default ruleset there is almost nothing left to detect, and the probe below would still pass on whatever remains.',
     };
   }
-  if (/(?:^|[{,])\s*disabledRules\s*=\s*\[\s*[^\]\s]/m.test(config)) {
+  if (/(?:^|[{,.])\s*(['"]?)disabledRules\1\s*=\s*\[\s*[^\]\s]/m.test(config)) {
     return {
       ok: false,
       reason:
         'the gitleaks config disables rules. Disabling a rule class is invisible to the probe below, which only proves that ONE rule still fires. If a rule genuinely false-positives, allowlist the offending VALUE with a `regexes` entry instead.',
     };
   }
-  if (/(?:^|[{,])\s*paths\s*=/m.test(config)) {
+  if (/(?:^|[{,.])\s*(['"]?)paths\1\s*=/m.test(config)) {
     return {
       ok: false,
       reason:

--- a/scripts/check-gitleaks-fixture.mjs
+++ b/scripts/check-gitleaks-fixture.mjs
@@ -29,6 +29,49 @@ export function interpretGitleaksRun(res) {
   return { ok: true };
 }
 
+// The step-2 probe below proves the config still catches a github-pat. It CANNOT prove the
+// config is otherwise intact: `disabledRules`, a stopword, a regex allowlist scoped to another
+// credential class, or a `paths` entry scoped to a real repo path all leave the probe green
+// while gutting the scanner for the secrets this repo actually holds. Those are shape defects,
+// so they are checked as shape.
+export function assertConfigShape(config, hasIgnoreFile, allowComments) {
+  if (!/useDefault\s*=\s*true/.test(config)) {
+    return {
+      ok: false,
+      reason:
+        'the gitleaks config does not set `useDefault = true`. Without the default ruleset there is almost nothing left to detect, and the probe below would still pass on whatever remains.',
+    };
+  }
+  if (/^\s*disabledRules\s*=\s*\[\s*[^\]\s]/m.test(config)) {
+    return {
+      ok: false,
+      reason:
+        'the gitleaks config disables rules. Disabling a rule class is invisible to the probe below, which only proves that ONE rule still fires. If a rule genuinely false-positives, allowlist the offending VALUE with a `regexes` entry instead.',
+    };
+  }
+  if (/^\s*paths\s*=/m.test(config)) {
+    return {
+      ok: false,
+      reason:
+        'a gitleaks allowlist uses `paths`. Measured on 8.30: a `paths` entry exempts that file from EVERY rule, which makes it a permanent secret-laundering path — a real credential committed there would never be seen again. Allowlist the VALUE with `regexes` instead. This is not stylistic: three files in this repo were exempt from everything, including a test suite full of real-shaped tokens.',
+    };
+  }
+  if (hasIgnoreFile) {
+    return {
+      ok: false,
+      reason:
+        'a .gitleaksignore file exists. gitleaks silently skips every fingerprint listed there, and nothing else in this gate would notice. Fix the finding or allowlist the value in .gitleaks.toml, where the reason is reviewable.',
+    };
+  }
+  if (allowComments.length > 0) {
+    return {
+      ok: false,
+      reason: `"gitleaks:allow" appears in ${allowComments.join(', ')}. That comment makes gitleaks skip the line, with no record of why and nothing gating it. It is the cheapest way to make this whole gate lie. Allowlist the value in .gitleaks.toml instead.`,
+    };
+  }
+  return { ok: true };
+}
+
 export function assertExpectedFindings(findings) {
   const byFile = new Map();
   for (const finding of findings) {
@@ -100,7 +143,40 @@ function scan(dir, report, configPath) {
   return spawnSync(GITLEAKS_BIN, args, { encoding: 'utf8', env: scannerEnv() });
 }
 
+const GITLEAKS_IGNORE = '.gitleaksignore';
+const ALLOW_COMMENT = 'gitleaks:allow';
+
+// These files NAME the suppression comment in order to ban it or explain the ban. They do not
+// use it. Everything else that contains the string is suppressing a gitleaks finding, which is
+// what this refuses. Keep this list at three.
+const MAY_NAME_THE_COMMENT = [
+  'scripts/check-gitleaks-fixture.mjs',
+  'scripts/gitleaks-staged.mjs',
+  'docs/superpowers/plans/',
+];
+
+function trackedFilesContaining(needle) {
+  const listed = spawnSync('git', ['grep', '-l', '--fixed-strings', needle, '--', '.'], {
+    encoding: 'utf8',
+  });
+  return String(listed.stdout ?? '')
+    .split('\n')
+    .filter((file) => file !== '')
+    .filter((file) => !MAY_NAME_THE_COMMENT.some((allowed) => file.startsWith(allowed)));
+}
+
 function main() {
+  const shape = assertConfigShape(
+    readFileSync(REPO_CONFIG, 'utf8'),
+    existsSync(GITLEAKS_IGNORE),
+    trackedFilesContaining(ALLOW_COMMENT),
+  );
+  if (!shape.ok) {
+    console.error(`[check-gitleaks-fixture] ${shape.reason}`);
+    process.exitCode = 1;
+    return;
+  }
+
   const tmp = mkdtempSync(join(tmpdir(), 'gitleaks-fixture-'));
   try {
     cpSync(join(FIXTURE_DIR, LEAKY_FIXTURE), join(tmp, LEAKY_FIXTURE));

--- a/scripts/check-gitleaks-fixture.mjs
+++ b/scripts/check-gitleaks-fixture.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+export const EXPECTED_RULES = ['github-pat'];
+export const LEAKY_FIXTURE = 'leaky.ts';
+export const CLEAN_FIXTURE = 'clean.ts';
+
+const NO_LEAKS = 0;
+const LEAKS_FOUND = 1;
+
+export function interpretGitleaksRun(res) {
+  if (res.error || res.status === null) {
+    return {
+      ok: false,
+      reason: `gitleaks did not run (${res.error?.message ?? 'killed by a signal'}). A scanner that never ran reports zero leaks, which is indistinguishable from a clean tree.`,
+    };
+  }
+  if (res.status !== NO_LEAKS && res.status !== LEAKS_FOUND) {
+    return {
+      ok: false,
+      reason: `gitleaks exited ${res.status}, which is neither ${NO_LEAKS} (no leaks) nor ${LEAKS_FOUND} (leaks found): ${String(res.stderr).trim()}`,
+    };
+  }
+  if (res.status === NO_LEAKS) {
+    return {
+      ok: false,
+      reason: `gitleaks ran and found NOTHING in a fixture that plants a real ${EXPECTED_RULES.join(', ')} secret. The scanner is not firing, so a green secret-scan on the real tree would mean nothing.`,
+    };
+  }
+  return { ok: true };
+}
+
+export function assertExpectedFindings(findings) {
+  const byFile = new Map();
+  for (const finding of findings) {
+    const base = String(finding.File ?? '')
+      .split('/')
+      .pop();
+    if (!byFile.has(base)) byFile.set(base, []);
+    byFile.get(base).push(String(finding.RuleID ?? ''));
+  }
+
+  const leakyRules = byFile.get(LEAKY_FIXTURE) ?? [];
+  for (const rule of EXPECTED_RULES) {
+    if (!leakyRules.includes(rule)) {
+      return {
+        ok: false,
+        reason: `${LEAKY_FIXTURE} did not trigger the expected rule "${rule}" (found: ${leakyRules.join(', ') || 'none'}). Either the rule was removed from the config, or the planted secret no longer matches it — in both cases the real scan is no longer proven to detect this class.`,
+      };
+    }
+  }
+
+  const cleanRules = byFile.get(CLEAN_FIXTURE) ?? [];
+  if (cleanRules.length > 0) {
+    return {
+      ok: false,
+      reason: `${CLEAN_FIXTURE} produced ${cleanRules.length} finding(s), expected 0: ${cleanRules.join(', ')}. A scanner that fires on clean code trains people to ignore it.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const FIXTURE_DIR = 'tests/fixtures/gitleaks';
+const REPORT_FILE = 'gitleaks-fixture.json';
+const GITLEAKS_BIN = process.env.GITLEAKS_BIN ?? 'gitleaks';
+
+function main() {
+  const tmp = mkdtempSync(join(tmpdir(), 'gitleaks-fixture-'));
+  try {
+    cpSync(join(FIXTURE_DIR, LEAKY_FIXTURE), join(tmp, LEAKY_FIXTURE));
+    cpSync(join(FIXTURE_DIR, CLEAN_FIXTURE), join(tmp, CLEAN_FIXTURE));
+    const report = join(tmp, REPORT_FILE);
+
+    const res = spawnSync(
+      GITLEAKS_BIN,
+      ['dir', tmp, '--no-banner', '--redact', '--report-format', 'json', '--report-path', report],
+      { encoding: 'utf8' },
+    );
+
+    const ran = interpretGitleaksRun(res);
+    if (!ran.ok) {
+      console.error(`[check-gitleaks-fixture] ${ran.reason}`);
+      process.exit(1);
+    }
+
+    const findings = JSON.parse(readFileSync(report, 'utf8'));
+    const verdict = assertExpectedFindings(findings);
+    if (!verdict.ok) {
+      console.error(`[check-gitleaks-fixture] ${verdict.reason}`);
+      process.exit(1);
+    }
+
+    console.log(
+      `[check-gitleaks-fixture] PASS — gitleaks fires on ${LEAKY_FIXTURE} (${EXPECTED_RULES.join(', ')}) and stays silent on ${CLEAN_FIXTURE}.`,
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/check-gitleaks-fixture.mjs
+++ b/scripts/check-gitleaks-fixture.mjs
@@ -148,12 +148,25 @@ const ALLOW_COMMENT = 'gitleaks:allow';
 
 // These files NAME the suppression comment in order to ban it or explain the ban. They do not
 // use it. Everything else that contains the string is suppressing a gitleaks finding, which is
-// what this refuses. Keep this list at three.
-const MAY_NAME_THE_COMMENT = [
+// what this refuses.
+//
+// The two source files are matched EXACTLY, not by prefix. A prefix would re-exempt any file
+// whose name merely starts with one of them -- e.g. a committed `scripts/gitleaks-staged.mjs.bak`
+// or `.orig` -- letting it carry `gitleaks:allow` unnoticed. That is the same "a prefix exempts
+// more than intended" bypass this PR closed for .gitleaks.toml's allowlists; it must not come
+// back through this list. Only the docs directory is a genuine prefix.
+const MAY_NAME_THE_COMMENT_FILES = [
   'scripts/check-gitleaks-fixture.mjs',
   'scripts/gitleaks-staged.mjs',
-  'docs/superpowers/plans/',
 ];
+const MAY_NAME_THE_COMMENT_DIRS = ['docs/superpowers/plans/'];
+
+export function mayNameTheComment(file) {
+  return (
+    MAY_NAME_THE_COMMENT_FILES.includes(file) ||
+    MAY_NAME_THE_COMMENT_DIRS.some((dir) => file.startsWith(dir))
+  );
+}
 
 const GREP_MATCHED = 0;
 const GREP_NO_MATCH = 1;
@@ -173,7 +186,7 @@ function trackedFilesContaining(needle) {
   return String(listed.stdout ?? '')
     .split('\n')
     .filter((file) => file !== '')
-    .filter((file) => !MAY_NAME_THE_COMMENT.some((allowed) => file.startsWith(allowed)));
+    .filter((file) => !mayNameTheComment(file));
 }
 
 function main() {

--- a/scripts/check-gitleaks-fixture.mjs
+++ b/scripts/check-gitleaks-fixture.mjs
@@ -61,43 +61,105 @@ export function assertExpectedFindings(findings) {
 }
 
 import { spawnSync } from 'node:child_process';
-import { cpSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const FIXTURE_DIR = 'tests/fixtures/gitleaks';
+const REPO_CONFIG = '.gitleaks.toml';
 const REPORT_FILE = 'gitleaks-fixture.json';
+const PROBE_FILE = 'config-probe.ts';
 const GITLEAKS_BIN = process.env.GITLEAKS_BIN ?? 'gitleaks';
+
+// Assembled at runtime so the literal never appears in this file — otherwise the repo scan
+// would flag this script. It is NOT the token .gitleaks.toml allowlists: the whole point of
+// the probe below is to scan a secret the repo config does not exempt.
+const PROBE_TOKEN = ['ghp', 'Pr0beNotAllowlisted0123456789abcdefg'].join('_');
+
+// GITLEAKS_CONFIG is honoured even with no --config flag, so the default-rules pass below
+// would silently become "whatever that env var points at". Strip it rather than assume.
+function scannerEnv() {
+  const env = { ...process.env };
+  delete env.GITLEAKS_CONFIG;
+  return env;
+}
+
+function scan(dir, report, configPath) {
+  const args = [
+    'dir',
+    dir,
+    '--no-banner',
+    '--redact',
+    '--report-format',
+    'json',
+    '--report-path',
+    report,
+  ];
+  if (configPath !== undefined) args.push('--config', configPath);
+  return spawnSync(GITLEAKS_BIN, args, { encoding: 'utf8', env: scannerEnv() });
+}
 
 function main() {
   const tmp = mkdtempSync(join(tmpdir(), 'gitleaks-fixture-'));
   try {
     cpSync(join(FIXTURE_DIR, LEAKY_FIXTURE), join(tmp, LEAKY_FIXTURE));
     cpSync(join(FIXTURE_DIR, CLEAN_FIXTURE), join(tmp, CLEAN_FIXTURE));
-    const report = join(tmp, REPORT_FILE);
 
-    const res = spawnSync(
-      GITLEAKS_BIN,
-      ['dir', tmp, '--no-banner', '--redact', '--report-format', 'json', '--report-path', report],
-      { encoding: 'utf8' },
-    );
-
-    const ran = interpretGitleaksRun(res);
+    // 1. The scanner fires at all. Scanned WITHOUT the repo config, so no allowlist here
+    //    can hide the bait from the one check that proves gitleaks works.
+    const defaultReport = join(tmp, REPORT_FILE);
+    const defaultRun = scan(tmp, defaultReport, undefined);
+    const ran = interpretGitleaksRun(defaultRun);
     if (!ran.ok) {
       console.error(`[check-gitleaks-fixture] ${ran.reason}`);
       process.exit(1);
     }
-
-    const findings = JSON.parse(readFileSync(report, 'utf8'));
-    const verdict = assertExpectedFindings(findings);
+    const verdict = assertExpectedFindings(JSON.parse(readFileSync(defaultReport, 'utf8')));
     if (!verdict.ok) {
       console.error(`[check-gitleaks-fixture] ${verdict.reason}`);
       process.exit(1);
     }
 
+    // 2. The REPO CONFIG still catches secrets. Step 1 cannot see this — it never loads
+    //    .gitleaks.toml — so an allowlist widened to `paths = ['''.*''']` would neuter the
+    //    real scan while step 1 stayed green and ci-gate went green with it. This scans a
+    //    DIFFERENT, non-exempt secret under the repo config. It must still fire.
+    const probeDir = mkdtempSync(join(tmpdir(), 'gitleaks-config-probe-'));
+    try {
+      writeFileSync(join(probeDir, PROBE_FILE), `export const t = '${PROBE_TOKEN}';\n`);
+      const probeReport = join(probeDir, REPORT_FILE);
+      const probeRun = scan(probeDir, probeReport, resolve(REPO_CONFIG));
+      const probeRan = interpretGitleaksRun(probeRun);
+      const neutered = `The repo config no longer detects a secret it is supposed to detect. An allowlist widened past the token it was written for — a "paths" entry (which exempts a file from EVERY rule), or an over-broad regex — disables the scanner for the REAL scan while the default-rules check above keeps passing. That is a green gate over no scanning at all.`;
+
+      if (!probeRan.ok) {
+        console.error(
+          `[check-gitleaks-fixture] under ${REPO_CONFIG}: ${probeRan.reason}\n\n${neutered}`,
+        );
+        process.exit(1);
+      }
+      if (!existsSync(probeReport)) {
+        console.error(
+          `[check-gitleaks-fixture] gitleaks reported leaks under ${REPO_CONFIG} but wrote no report to ${probeReport}.`,
+        );
+        process.exit(1);
+      }
+      const probeRules = JSON.parse(readFileSync(probeReport, 'utf8')).map((f) => String(f.RuleID));
+      for (const rule of EXPECTED_RULES) {
+        if (!probeRules.includes(rule)) {
+          console.error(
+            `[check-gitleaks-fixture] under ${REPO_CONFIG}, a non-allowlisted secret did NOT trigger "${rule}" (found: ${probeRules.join(', ') || 'none'}).\n\n${neutered}`,
+          );
+          process.exit(1);
+        }
+      }
+    } finally {
+      rmSync(probeDir, { recursive: true, force: true });
+    }
+
     console.log(
-      `[check-gitleaks-fixture] PASS — gitleaks fires on ${LEAKY_FIXTURE} (${EXPECTED_RULES.join(', ')}) and stays silent on ${CLEAN_FIXTURE}.`,
+      `[check-gitleaks-fixture] PASS — gitleaks fires on ${LEAKY_FIXTURE} (${EXPECTED_RULES.join(', ')}), stays silent on ${CLEAN_FIXTURE}, and ${REPO_CONFIG} still catches a secret it does not allowlist.`,
     );
   } finally {
     rmSync(tmp, { recursive: true, force: true });

--- a/scripts/gitleaks-staged.d.mts
+++ b/scripts/gitleaks-staged.d.mts
@@ -1,0 +1,16 @@
+export declare const NO_LEAKS: number;
+export declare const LEAKS_FOUND: number;
+export declare const MISSING_BINARY: string;
+export declare const SECRET_STAGED: string;
+
+export interface StagedRun {
+  error?: Error;
+  status: number | null;
+}
+
+export interface StagedVerdict {
+  block: boolean;
+  reason?: string;
+}
+
+export declare function decideStagedExit(res: StagedRun): StagedVerdict;

--- a/scripts/gitleaks-staged.d.mts
+++ b/scripts/gitleaks-staged.d.mts
@@ -14,3 +14,4 @@ export interface StagedVerdict {
 }
 
 export declare function decideStagedExit(res: StagedRun): StagedVerdict;
+export declare const SCANNER_KILLED: string;

--- a/scripts/gitleaks-staged.mjs
+++ b/scripts/gitleaks-staged.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+
+const NO_LEAKS = 0;
+const LEAKS_FOUND = 1;
+const GITLEAKS_BIN = process.env.GITLEAKS_BIN ?? 'gitleaks';
+
+const res = spawnSync(
+  GITLEAKS_BIN,
+  ['git', '--staged', '--no-banner', '--redact', '--config', '.gitleaks.toml'],
+  { stdio: 'inherit' },
+);
+
+if (res.error !== undefined || res.status === null) {
+  console.error(
+    `\n[gitleaks] could not run gitleaks (${res.error?.message ?? 'killed by a signal'}).\n` +
+      '\nThis hook fails closed on purpose. A secret-scanner that silently skips when it is\n' +
+      'missing is the same as no scanner, and you would never find out. Install it:\n' +
+      '\n  brew install gitleaks\n' +
+      '\nCI runs the same scan on a pinned binary, so a bypass here is caught there --\n' +
+      'but only AFTER the secret is already in git history, which is the thing this\n' +
+      'hook exists to prevent.\n',
+  );
+  process.exit(1);
+}
+
+if (res.status === LEAKS_FOUND) {
+  console.error(
+    '\n[gitleaks] a secret was found in the STAGED changes; the commit is blocked.\n' +
+      '\nThe finding is above (values redacted). Once a secret reaches a commit it is in\n' +
+      'git history, and pushing publishes it -- rotating the credential is then the only\n' +
+      'real remedy. Unstage it, move the value to an env var, and commit again.\n' +
+      '\nIf it is a false positive, add a scoped allowlist to .gitleaks.toml -- a path\n' +
+      'entry, not a rule disable.\n',
+  );
+  process.exit(1);
+}
+
+if (res.status !== NO_LEAKS) {
+  console.error(
+    `\n[gitleaks] exited ${res.status}, which is neither ${NO_LEAKS} (clean) nor ${LEAKS_FOUND} (leaks found). Treating an unknown exit code as clean would be a fail-open.\n`,
+  );
+  process.exit(1);
+}

--- a/scripts/gitleaks-staged.mjs
+++ b/scripts/gitleaks-staged.mjs
@@ -31,8 +31,11 @@ if (res.status === LEAKS_FOUND) {
       '\nThe finding is above (values redacted). Once a secret reaches a commit it is in\n' +
       'git history, and pushing publishes it -- rotating the credential is then the only\n' +
       'real remedy. Unstage it, move the value to an env var, and commit again.\n' +
-      '\nIf it is a false positive, add a scoped allowlist to .gitleaks.toml -- a path\n' +
-      'entry, not a rule disable.\n',
+      '\nIf it is a false positive, add a `regexes` entry to .gitleaks.toml matching the\n' +
+      'exact VALUE. Never a `paths` entry: a paths entry exempts that whole file from\n' +
+      'every rule, so a real credential committed there later would never be seen. And\n' +
+      'never a "gitleaks:allow" comment or a .gitleaksignore -- both are unreviewable,\n' +
+      'and scripts/check-gitleaks-fixture.mjs fails the build if either appears.\n',
   );
   process.exit(1);
 }

--- a/scripts/gitleaks-staged.mjs
+++ b/scripts/gitleaks-staged.mjs
@@ -1,48 +1,72 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'node:child_process';
+export const NO_LEAKS = 0;
+export const LEAKS_FOUND = 1;
 
-const NO_LEAKS = 0;
-const LEAKS_FOUND = 1;
+export const MISSING_BINARY = [
+  '\n[gitleaks] could not run gitleaks.\n',
+  '\nThis hook fails closed on purpose. A secret-scanner that silently skips when it is',
+  'missing is the same as no scanner, and you would never find out. Install it:\n',
+  '\n  brew install gitleaks\n',
+  '\nCI runs the same scan on a pinned binary, so a bypass here is caught there -- but only',
+  'AFTER the secret is already in git history, which is the thing this hook exists to',
+  'prevent.\n',
+].join('\n');
+
+export const SECRET_STAGED = [
+  '\n[gitleaks] a secret was found in the STAGED changes; the commit is blocked.\n',
+  '\nThe finding is above (values redacted). Once a secret reaches a commit it is in git',
+  'history, and pushing publishes it -- rotating the credential is then the only real',
+  'remedy. Unstage it, move the value to an env var, and commit again.\n',
+  '\nIf it is a false positive, add a `regexes` entry to .gitleaks.toml matching the exact',
+  'VALUE. Never a `paths` entry: a paths entry exempts that whole file from every rule, so',
+  'a real credential committed there later would never be seen. And never a "gitleaks:allow"',
+  'comment or a .gitleaksignore -- both are unreviewable, and scripts/check-gitleaks-fixture.mjs',
+  'fails the build if either appears.\n',
+].join('\n');
+
+// The exit-code decision, kept pure so it can be tested. It is the entire fail-closed defence
+// of the local gate, and it runs on every commit -- the sibling self-test script has its
+// equivalent tested exhaustively, and this one had nothing.
+export function decideStagedExit(res) {
+  if (res.error !== undefined || res.status === null) {
+    const cause = res.error?.message ?? 'gitleaks was killed before it could answer';
+    return { block: true, reason: `${MISSING_BINARY}\n(${cause})\n` };
+  }
+  if (res.status === LEAKS_FOUND) {
+    return { block: true, reason: SECRET_STAGED };
+  }
+  if (res.status !== NO_LEAKS) {
+    return {
+      block: true,
+      reason: `\n[gitleaks] exited ${res.status}, which is neither ${NO_LEAKS} (clean) nor ${LEAKS_FOUND} (leaks found). A malformed .gitleaks.toml exits non-zero, and reading an unknown exit code as "clean" is exactly how a secret gate goes green while scanning nothing.\n`,
+    };
+  }
+  return { block: false };
+}
+
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
 const GITLEAKS_BIN = process.env.GITLEAKS_BIN ?? 'gitleaks';
 
-const res = spawnSync(
-  GITLEAKS_BIN,
-  ['git', '--staged', '--no-banner', '--redact', '--config', '.gitleaks.toml'],
-  { stdio: 'inherit' },
-);
-
-if (res.error !== undefined || res.status === null) {
-  console.error(
-    `\n[gitleaks] could not run gitleaks (${res.error?.message ?? 'killed by a signal'}).\n` +
-      '\nThis hook fails closed on purpose. A secret-scanner that silently skips when it is\n' +
-      'missing is the same as no scanner, and you would never find out. Install it:\n' +
-      '\n  brew install gitleaks\n' +
-      '\nCI runs the same scan on a pinned binary, so a bypass here is caught there --\n' +
-      'but only AFTER the secret is already in git history, which is the thing this\n' +
-      'hook exists to prevent.\n',
+function main() {
+  const res = spawnSync(
+    GITLEAKS_BIN,
+    ['git', '--staged', '--no-banner', '--redact', '--config', '.gitleaks.toml'],
+    { stdio: 'inherit' },
   );
-  process.exit(1);
+
+  const verdict = decideStagedExit(res);
+  if (verdict.block) {
+    console.error(verdict.reason);
+    process.exitCode = 1;
+  }
 }
 
-if (res.status === LEAKS_FOUND) {
-  console.error(
-    '\n[gitleaks] a secret was found in the STAGED changes; the commit is blocked.\n' +
-      '\nThe finding is above (values redacted). Once a secret reaches a commit it is in\n' +
-      'git history, and pushing publishes it -- rotating the credential is then the only\n' +
-      'real remedy. Unstage it, move the value to an env var, and commit again.\n' +
-      '\nIf it is a false positive, add a `regexes` entry to .gitleaks.toml matching the\n' +
-      'exact VALUE. Never a `paths` entry: a paths entry exempts that whole file from\n' +
-      'every rule, so a real credential committed there later would never be seen. And\n' +
-      'never a "gitleaks:allow" comment or a .gitleaksignore -- both are unreviewable,\n' +
-      'and scripts/check-gitleaks-fixture.mjs fails the build if either appears.\n',
-  );
-  process.exit(1);
-}
-
-if (res.status !== NO_LEAKS) {
-  console.error(
-    `\n[gitleaks] exited ${res.status}, which is neither ${NO_LEAKS} (clean) nor ${LEAKS_FOUND} (leaks found). Treating an unknown exit code as clean would be a fail-open.\n`,
-  );
-  process.exit(1);
+if (
+  typeof process.argv[1] === 'string' &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
 }

--- a/scripts/gitleaks-staged.mjs
+++ b/scripts/gitleaks-staged.mjs
@@ -28,10 +28,19 @@ export const SECRET_STAGED = [
 // The exit-code decision, kept pure so it can be tested. It is the entire fail-closed defence
 // of the local gate, and it runs on every commit -- the sibling self-test script has its
 // equivalent tested exhaustively, and this one had nothing.
+export const SCANNER_KILLED = [
+  '\n[gitleaks] gitleaks was killed before it could answer; the commit is blocked.\n',
+  '\nThe binary is installed -- it started and died, so nothing was scanned. That is not a',
+  'clean tree, and this hook will not report one. Re-run the commit; if it keeps dying, check',
+  'for an OOM kill.\n',
+].join('\n');
+
 export function decideStagedExit(res) {
-  if (res.error !== undefined || res.status === null) {
-    const cause = res.error?.message ?? 'gitleaks was killed before it could answer';
-    return { block: true, reason: `${MISSING_BINARY}\n(${cause})\n` };
+  if (res.error !== undefined) {
+    return { block: true, reason: `${MISSING_BINARY}\n(${res.error.message})\n` };
+  }
+  if (res.status === null) {
+    return { block: true, reason: SCANNER_KILLED };
   }
   if (res.status === LEAKS_FOUND) {
     return { block: true, reason: SECRET_STAGED };

--- a/tests/fixtures/gitleaks/clean.ts
+++ b/tests/fixtures/gitleaks/clean.ts
@@ -1,0 +1,1 @@
+export const githubToken = process.env.GITHUB_TOKEN ?? '';

--- a/tests/fixtures/gitleaks/leaky.ts
+++ b/tests/fixtures/gitleaks/leaky.ts
@@ -1,0 +1,1 @@
+export const githubToken = 'ghp_R2d2c3poAbCdEfGhIjKlMnOpQrStUvWx1234';


### PR DESCRIPTION
## Summary

Two things, both about **gates that do not gate what they claim to**.

**1. Secret scanning was not running on this repo. At all.**
`gitleaks` is installed via a **global** `core.hooksPath`, but husky sets a **local** one — and local wins. So the effective `pre-commit` ran only `pnpm check`. No CI job invoked gitleaks either. Meanwhile `.gitleaks.toml` sat in the tree with hand-tuned allowlists, implying a scanner that had never run.

**Measured before building anything — full history, 149 commits, 6.99 MB: no credential was ever leaked.** The one hit is our own planted semgrep fixture. `.env` has never been committed; only `.env.example`, whose values are placeholders (`vck_...`, `re_...`, `your-token-here`). **Nothing to rotate.**

**2. The `.gitignore` meta-gate (merged in #192) kept shipping false failure messages** — six of them across six review rounds, including one about git's own behaviour I asserted without ever running it. Root cause: **no passing run renders a failure message**, so nothing held them.

## Type of change

- [x] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [ ] `chore` / `ci` / `docs` — non-functional

## Test plan

- [x] `pnpm ci:local` passes
- [x] New behaviour covered by tests

`pnpm typecheck` PASS · `pnpm check` PASS · `pnpm test --run` **1194 passed** (was 1167).

### The gitleaks gate is proven to fire, not assumed to

| Check | Result |
|---|---|
| Self-test: gitleaks fires on a planted `github-pat`, silent on clean code | **PASS** |
| Full history scan (149 commits) | **0 findings** |
| A real secret planted elsewhere in `lib/` | **CAUGHT** |
| A secret **staged** → pre-commit | **blocked, exit 1** |
| Clean staged tree → pre-commit | **exit 0**, no false positive |
| Tampered binary tarball | **checksum FAILS**, refuses to install |
| **`.gitleaks.toml` neutered (`paths = '.*'`)** | **RED** — see below |

### Three fail-opens found and closed *in my own gate*

- **Nothing gated `.gitleaks.toml` itself.** The self-test scans the bait *without* `--config` (correct — otherwise an allowlist could hide it). But that meant no gate covered the repo config: widen an allowlist to `paths = ['''.*''']` and the self-test still passes, the repo scan reports clean, `ci-gate` goes green — **scanner fully neutered, zero red.** The self-test now also scans a *different, non-allowlisted* secret **under** the repo config.
- **The fixtures were secret-laundering paths.** Measured on gitleaks 8.30: **any `paths` entry exempts a file from every rule**, and neither `condition = "AND"` nor `matchCondition = "AND"` narrows it (I tried both). A real credential parked in `leaky.ts` would have been invisible **forever**. Both allowlists are now `regexes`-only, scoped to the exact planted token.
- **The binary was verified by asking it its version.** A tampered binary prints whatever version it likes. Now checksum-verified (sha256, exact-filename lookup) before extraction.

### The meta-gate's messages are now held by a gate

The previous fix gated `describeGitFailure`/`gitAnswered` — but **not the two big assertion messages, where all six drifts actually happened.** Review proved it by planting falsehoods in them and watching every test stay green.

Every claim those messages make is a measurable git fact, so a matrix now measures it — rule shape × materialisation, plus a negation witness and a mode-`120000` staging witness:

| rule | symlink | dir | contents |
|---|---|---|---|
| `/X` | ignored | ignored | ignored |
| `/X/` | **not** | ignored | ignored |
| `/X/**` | **not** | **not** | ignored |
| `X` (unanchored) | ignored | ignored | ignored |
| `/X` + `!/X/` | ignored | **not** | **not** |

That last row killed a claim I had shipped: *"if both are false, no rule matches at all"* — **false**, a present rule can lose to a negation. And `/X/**` leaves the **symlink** stageable as a `120000` blob, so *"nothing becomes committable"* was false too.

Planting the reviewer's exact falsehood (`/X/` matches the symlink) now **reds the suite**.

## Visual changes

None. No rendered surface is touched.

## Checklist

- [x] No hardcoded hex values / magic numbers — literals extracted to named consts
- [x] No `use client` added without necessity — n/a
- [x] Bundle size impact assessed — zero client bytes (CI job, scripts, fixtures, one test)
- [x] A11y impact considered — no rendered surface touched
- [x] ADR added to `DECISIONS.md` if this changes architecture — not needed; the gates hold the properties and the commit bodies carry the causal chains

## Known follow-ups (logged, not in this PR)

- **Nothing bumps the gitleaks `8.30.0` pin** — Dependabot covers npm and Actions, not binary tools. Same gap applies to semgrep's pip pin.
- `--no-verify` still bypasses the local hook; CI's history scan blocks the *merge*, but a pushed secret is already published and must be rotated. Pre-push has no secret scan.
- Agent worktrees leak ~10MB each (the harness auto-clean only fires when the agent wrote nothing).
- `AGENTS.md` / `.agents/` / `.codex/` are untracked **and** unignored.
- `.gitignore` does not match `.env.production` / `.env.development`.