### PR TITLE
feat(ci): fail loudly when a pinned scanner (gitleaks/semgrep) falls behind upstream

### DIFF
--- a/.github/workflows/tool-pins.yml
+++ b/.github/workflows/tool-pins.yml
@@ -27,4 +27,8 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Check gitleaks and semgrep pins against upstream
+        env:
+          # Authenticates the GitHub Releases call so a shared-runner-IP rate limit cannot
+          # produce a spurious red run. The token is contents:read only (see permissions above).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/check-tool-pins.mjs

--- a/.github/workflows/tool-pins.yml
+++ b/.github/workflows/tool-pins.yml
@@ -1,0 +1,30 @@
+name: Scanner Pin Freshness
+
+# The security scanners (gitleaks, semgrep) are pinned by exact version in ci.yml. Dependabot
+# does not track binary/CLI tools, so nothing otherwise tells us when a pin falls behind and a
+# scanner starts running without upstream security patches. This weekly job is that signal: it
+# fails loudly (a red run + email) when a pin is behind, naming the current and latest versions.
+# It is intentionally NOT in ci-gate and blocks no PR -- a stale pin is a nudge, not a merge stop.
+
+on:
+  schedule:
+    - cron: '0 5 * * 1' # Weekly Monday 05:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tool-pins:
+    name: Scanner pins are current
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Check gitleaks and semgrep pins against upstream
+        run: node scripts/check-tool-pins.mjs

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:fix": "biome check --write .",
     "gitleaks:staged": "node scripts/gitleaks-staged.mjs",
     "gitleaks:fixture": "node scripts/check-gitleaks-fixture.mjs",
+    "check:tool-pins": "node scripts/check-tool-pins.mjs",
     "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/scripts/__tests__/check-tool-pins.test.ts
+++ b/scripts/__tests__/check-tool-pins.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { isBehind, parseVersion, readPin } from '../check-tool-pins.mjs';
+
+describe('parseVersion', () => {
+  it('parses a bare semver', () => {
+    expect(parseVersion('8.30.0')).toEqual([8, 30, 0]);
+  });
+
+  it('strips a leading v (gitleaks tags are v8.30.1)', () => {
+    expect(parseVersion('v8.30.1')).toEqual([8, 30, 1]);
+  });
+
+  it('throws on a non-version so a garbled upstream response cannot be read as "up to date"', () => {
+    expect(() => parseVersion('not-a-version')).toThrow();
+    expect(() => parseVersion('')).toThrow();
+  });
+});
+
+describe('isBehind (numeric comparison, not lexical)', () => {
+  it('a pin equal to latest is not behind', () => {
+    expect(isBehind('8.30.0', '8.30.0')).toBe(false);
+  });
+
+  it('a pin one patch back is behind', () => {
+    expect(isBehind('8.30.0', '8.30.1')).toBe(true);
+  });
+
+  it('8.9.0 is behind 8.30.0 -- the lexical-vs-numeric trap', () => {
+    // String comparison would call "8.9.0" > "8.30.0" (because "9" > "3"). It is not.
+    expect(isBehind('8.9.0', '8.30.0')).toBe(true);
+    expect(isBehind('8.30.0', '8.9.0')).toBe(false);
+  });
+
+  it('1.100.0 is NOT behind 1.99.0 -- the other half of the same trap', () => {
+    expect(isBehind('1.100.0', '1.99.0')).toBe(false);
+    expect(isBehind('1.99.0', '1.100.0')).toBe(true);
+  });
+
+  it('a newer major beats any older minor/patch', () => {
+    expect(isBehind('1.999.999', '2.0.0')).toBe(true);
+    expect(isBehind('2.0.0', '1.999.999')).toBe(false);
+  });
+
+  it('the repo semgrep pin (1.97.0) is behind a far-newer PyPI release (1.169.0)', () => {
+    expect(isBehind('1.97.0', '1.169.0')).toBe(true);
+  });
+});
+
+describe('readPin (single source of truth: the pins live in ci.yml)', () => {
+  const CI = [
+    '        run: |',
+    '          pip install "setuptools<81" semgrep==1.97.0',
+    '    env:',
+    '      GITLEAKS_VERSION: 8.30.0',
+  ].join('\n');
+
+  it('reads the gitleaks pin', () => {
+    expect(readPin(CI, /GITLEAKS_VERSION:\s*(\d+\.\d+\.\d+)/, 'gitleaks')).toBe('8.30.0');
+  });
+
+  it('reads the semgrep pin', () => {
+    expect(readPin(CI, /semgrep==(\d+\.\d+\.\d+)/, 'semgrep')).toBe('1.97.0');
+  });
+
+  it('throws when the pin cannot be found, rather than reporting a phantom version', () => {
+    expect(() => readPin(CI, /NONEXISTENT==(\d+\.\d+\.\d+)/, 'ghost')).toThrow(/ghost/);
+  });
+});

--- a/scripts/__tests__/check-tool-pins.test.ts
+++ b/scripts/__tests__/check-tool-pins.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isBehind, parseVersion, readPin } from '../check-tool-pins.mjs';
+import { buildHeaders, isBehind, parseVersion, readPin } from '../check-tool-pins.mjs';
 
 describe('parseVersion', () => {
   it('parses a bare semver', () => {
@@ -64,5 +64,32 @@ describe('readPin (single source of truth: the pins live in ci.yml)', () => {
 
   it('throws when the pin cannot be found, rather than reporting a phantom version', () => {
     expect(() => readPin(CI, /NONEXISTENT==(\d+\.\d+\.\d+)/, 'ghost')).toThrow(/ghost/);
+  });
+});
+
+describe('buildHeaders (the token reaches GitHub and nothing else)', () => {
+  const GH = 'https://api.github.com/repos/gitleaks/gitleaks/releases/latest';
+  const PYPI = 'https://pypi.org/pypi/semgrep/json';
+  const TOKEN = 'ghs_secrettokenvalue';
+
+  it('sends Authorization to api.github.com when a token is set', () => {
+    expect(buildHeaders(GH, TOKEN).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('NEVER sends Authorization to PyPI, even with a token set', () => {
+    expect(
+      buildHeaders(PYPI, TOKEN).Authorization,
+      'The GITHUB_TOKEN must be scoped to the GitHub host. Sending it to PyPI (or any non-GitHub URL) would leak the credential to a third party over the network.',
+    ).toBeUndefined();
+  });
+
+  it('sends no Authorization when no token is available (local runs, unauthenticated)', () => {
+    expect(buildHeaders(GH, undefined).Authorization).toBeUndefined();
+    expect(buildHeaders(GH, '').Authorization).toBeUndefined();
+  });
+
+  it('always sets a User-Agent (GitHub rejects requests without one)', () => {
+    expect(buildHeaders(GH, TOKEN)['User-Agent']).toBeTruthy();
+    expect(buildHeaders(PYPI, undefined)['User-Agent']).toBeTruthy();
   });
 });

--- a/scripts/check-tool-pins.d.mts
+++ b/scripts/check-tool-pins.d.mts
@@ -1,0 +1,19 @@
+export interface Pin {
+  name: string;
+  file: string;
+  pattern: RegExp;
+  latest: () => Promise<string>;
+  bumpHint: string;
+}
+
+export interface PinStatus {
+  name: string;
+  current: string;
+  latest: string;
+  behind: boolean;
+}
+
+export declare function parseVersion(raw: string): [number, number, number];
+export declare function isBehind(current: string, latest: string): boolean;
+export declare function readPin(fileText: string, pattern: RegExp, name: string): string;
+export declare const PINS: Pin[];

--- a/scripts/check-tool-pins.d.mts
+++ b/scripts/check-tool-pins.d.mts
@@ -17,3 +17,7 @@ export declare function parseVersion(raw: string): [number, number, number];
 export declare function isBehind(current: string, latest: string): boolean;
 export declare function readPin(fileText: string, pattern: RegExp, name: string): string;
 export declare const PINS: Pin[];
+export declare function buildHeaders(
+  url: string,
+  token: string | undefined,
+): Record<string, string>;

--- a/scripts/check-tool-pins.mjs
+++ b/scripts/check-tool-pins.mjs
@@ -105,12 +105,19 @@ async function main() {
   process.exitCode = 1;
 }
 
+// A GitHub Actions ::error:: annotation is line-delimited: a newline in the message would be
+// parsed as the start of a fresh workflow command. error.message can carry a raw upstream value
+// (parseVersion embeds the string it rejected), so collapse any CR/LF before emitting. Blast
+// radius is near-zero here (read-only token, no secrets, ref/version formats forbid newlines),
+// but the annotation should carry only what this script put there.
+const oneLine = (text) => String(text).replace(/[\r\n]+/g, ' ');
+
 if (
   typeof process.argv[1] === 'string' &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
   main().catch((error) => {
-    console.error(`::error::${error.message}`);
+    console.error(`::error::${oneLine(error.message)}`);
     process.exitCode = 1;
   });
 }

--- a/scripts/check-tool-pins.mjs
+++ b/scripts/check-tool-pins.mjs
@@ -32,10 +32,22 @@ export function readPin(fileText, pattern, name) {
   return match[1];
 }
 
+const GITHUB_HOST = 'api.github.com';
+
+// Authenticate the GitHub call when a token is available: the anonymous limit is 60 req/hr per IP,
+// and Actions runners share outbound IPs, so an unauthenticated call can 403 on a busy week and
+// red this job when nothing is actually behind -- a false positive that trains people to ignore
+// it. The token is scoped to the GitHub host ONLY; PyPI (and anything else) never receives it.
+export function buildHeaders(url, token) {
+  const headers = { 'User-Agent': 'erikunha-portfolio-pin-check', Accept: 'application/json' };
+  if (token !== undefined && token !== '' && new URL(url).host === GITHUB_HOST) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
 async function fetchJson(url) {
-  const res = await fetch(url, {
-    headers: { 'User-Agent': 'erikunha-portfolio-pin-check', Accept: 'application/json' },
-  });
+  const res = await fetch(url, { headers: buildHeaders(url, process.env.GITHUB_TOKEN) });
   if (!res.ok) {
     throw new Error(`${url} returned HTTP ${res.status}`);
   }

--- a/scripts/check-tool-pins.mjs
+++ b/scripts/check-tool-pins.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+const SEMVER = /^v?(\d+)\.(\d+)\.(\d+)/;
+
+export function parseVersion(raw) {
+  const match = SEMVER.exec(String(raw).trim());
+  if (match === null) {
+    throw new Error(
+      `"${raw}" is not a semver. Refusing to compare it: a garbled upstream response must not be read as "up to date", which would let a stale pin sit unnoticed.`,
+    );
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function isBehind(current, latest) {
+  const c = parseVersion(current);
+  const l = parseVersion(latest);
+  for (let i = 0; i < 3; i++) {
+    if (l[i] > c[i]) return true;
+    if (l[i] < c[i]) return false;
+  }
+  return false;
+}
+
+export function readPin(fileText, pattern, name) {
+  const match = pattern.exec(fileText);
+  if (match === null || match[1] === undefined) {
+    throw new Error(
+      `could not find the ${name} version pin (pattern ${pattern}). The pin is the single source of truth; if this check cannot read it, it must fail rather than silently report the pin as current.`,
+    );
+  }
+  return match[1];
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'erikunha-portfolio-pin-check', Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(`${url} returned HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+const latestGitleaks = async () => {
+  const release = await fetchJson('https://api.github.com/repos/gitleaks/gitleaks/releases/latest');
+  return String(release.tag_name);
+};
+
+const latestSemgrep = async () => {
+  const meta = await fetchJson('https://pypi.org/pypi/semgrep/json');
+  return String(meta.info.version);
+};
+
+const CI_YAML = '.github/workflows/ci.yml';
+
+export const PINS = [
+  {
+    name: 'gitleaks',
+    file: CI_YAML,
+    pattern: /GITLEAKS_VERSION:\s*(\d+\.\d+\.\d+)/,
+    latest: latestGitleaks,
+    bumpHint: `bump GITLEAKS_VERSION in ${CI_YAML}, then re-derive the sha256 in the checksum step`,
+  },
+  {
+    name: 'semgrep',
+    file: CI_YAML,
+    pattern: /semgrep==(\d+\.\d+\.\d+)/,
+    latest: latestSemgrep,
+    bumpHint: `bump the \`semgrep==\` pin in ${CI_YAML}`,
+  },
+];
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+async function statusOf(pin) {
+  const current = readPin(readFileSync(pin.file, 'utf8'), pin.pattern, pin.name);
+  const latest = parseVersion(await pin.latest()).join('.');
+  return { name: pin.name, current, latest, behind: isBehind(current, latest) };
+}
+
+async function main() {
+  // Fail CLOSED: if any pin cannot be read or any upstream cannot be reached, throw. This job is
+  // scheduled and non-blocking, so a red run is a visible, re-runnable nudge -- never a silent
+  // "everything is current" that lets a security scanner rot unpatched.
+  const statuses = await Promise.all(PINS.map(statusOf));
+  const behind = statuses.filter((s) => s.behind);
+
+  for (const s of statuses) {
+    console.log(
+      `${s.name}: pinned ${s.current}, latest ${s.latest}${s.behind ? '  <- BEHIND' : ''}`,
+    );
+  }
+
+  if (behind.length === 0) {
+    console.log('[check-tool-pins] all scanner pins are current.');
+    return;
+  }
+
+  for (const s of behind) {
+    const hint = PINS.find((p) => p.name === s.name)?.bumpHint ?? '';
+    console.error(`::error::${s.name} pin ${s.current} is behind latest ${s.latest}. ${hint}.`);
+  }
+  process.exitCode = 1;
+}
+
+if (
+  typeof process.argv[1] === 'string' &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- **Adds a weekly, non-blocking check that reports when the pinned security scanners are behind upstream.** gitleaks and semgrep are pinned by exact version in `ci.yml`; Dependabot doesn't track binary/CLI tools, so nothing told us when a pin fell behind and a scanner started running without upstream patches. Follow-up to #193 (which made gitleaks actually run).
- **It validates against reality on day one:** run today it correctly flags **both** pins as already stale (`gitleaks 8.30.0 -> 8.30.1`, `semgrep 1.97.0 -> 1.169.0`) with exact bump hints — the invisible drift this closes.
- **Bumping the versions is a deliberately separate change** (task tracked): gitleaks needs a re-derived checksum and semgrep is a 72-minor jump that could shift its gate. This PR makes the drift *visible*, not silently fixes it.

## Type of change

- [ ] `feat` — new functionality
- [ ] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional (a CI freshness check; ships no product code)

## Test plan

- [x] `pnpm ci:local` passes
- [x] New behaviour covered by tests

`pnpm typecheck` PASS · `pnpm check` PASS · `pnpm test --run` **1234 passed** · gitleaks self-test PASS.

The fragile core is gated, not assumed:

| Property | How it's held |
|---|---|
| **Numeric, not lexical, comparison** | tests for `8.9.0` vs `8.30.0` and `1.100.0` vs `1.99.0` — mutating `isBehind` to a string compare reds them |
| **Fail-closed** | a garbled upstream response (non-semver), an unreachable host (HTTP non-200 / fetch throws), or a pin the regex can't find in `ci.yml` all **throw** → exit 1, never "up to date" |
| **Single source of truth** | the pins are read *from* `ci.yml`; if a reformat breaks the regex, the check throws rather than reading a phantom version |
| **Token scoped to GitHub only** | `buildHeaders` sends the `GITHUB_TOKEN` Bearer to `api.github.com` and **never** to PyPI — a test asserts PyPI gets no `Authorization` even with a token set |

Verified end-to-end: run against live upstream it exits 1 and prints `::error::` annotations naming current-vs-latest and the line to bump.

### Design notes

- **Weekly + `workflow_dispatch`, NOT in `ci-gate`.** A stale pin is a nudge, not a merge stop — it blocks no PR. `on:` is `schedule` + `workflow_dispatch` only, so a fork PR can't trigger it.
- **`permissions: contents: read`** (least privilege). The `GITHUB_TOKEN` is passed only to authenticate the GitHub Releases call — the anonymous 60/hr limit on shared runner IPs could otherwise 403 and produce a *spurious* red run, which the repo's false-positive-budget rule treats as miscalibration. The token is host-scoped and never logged (and Actions masks it anyway).
- **`::error::` annotations are newline-collapsed** so a non-semver upstream tag can't inject a second workflow command.

## Visual changes

None. CI tooling only — no rendered surface.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — literals extracted to named consts
- [x] No `use client` added without necessity (RSC drift) — n/a
- [x] Bundle size impact assessed (`pnpm bundle-check`) — zero client bytes (CI script + workflow + test)
- [x] A11y impact considered (axe-core will gate in CI) — no rendered surface
- [x] ADR added to `DECISIONS.md` if this changes architecture — not needed; a CI freshness check, no architectural decision

## Known follow-up

- **Bump the stale pins** (tracked): `gitleaks 8.30.0 -> 8.30.1` (bump + re-derive checksum) and `semgrep 1.97.0 -> 1.169.0` (test the semgrep gate for behaviour drift on the large jump). Each in its own commit so a regression is bisectable. Once bumped, this check goes green.