### PR TITLE
fix(seo): move canonical host to www.erikunha.dev to match the live redirect

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2,6 +2,10 @@
 
 ADR-lite running log. One bullet per decision · date · reversibility note.
 
+## 2026-07-13 - Canonical host moved apex → www to match the live redirect
+
+- **2026-07-13** · **Migrated the canonical host from `erikunha.dev` to `www.erikunha.dev` across all self-referential URLs.** After #198 shipped, the apex was found to 308-redirect to www (Vercel primary-domain setting) while every canonical/og:url/sitemap/JSON-LD still pointed at the apex — a canonical URL that itself redirects, which partly undoes #198's dedup fix (search engines see the preferred host disagree with the serving host). Changed `metadataBase`, root `openGraph.url`/`alternates.canonical`/authors url, `content/seo.ts` (`personSchema.url` + breadcrumb `SITE_ORIGIN`), `content/social.ts`, `lib/hiring-profile.ts`, `lib/agent/mcp-tools.ts`, `public/{robots.txt,llms.txt,.well-known/agent.json}`, the two Footer self-link `href`s, the README "Live" badge, and the gate tests that assert those URLs — every scheme-prefixed (`https://…`) self-referential URL on a served or crawled surface. The operational `curl https://erikunha.dev/api/healthz` runbook lines intentionally keep the apex: a one-shot health check follows the 308 transparently and is not a canonical surface. **Brand/identity strings stay bare `erikunha.dev`** — OG `siteName`, the page-`<title>` suffix, the MCP server `name`, and the `@erikunha.dev` emails are display labels, not hosts. Owner chose www-canonical over the zero-code alternative (flip the Vercel primary domain to apex so www→apex, keeping the existing apex refs). Reversible: revert the host strings AND flip the Vercel primary domain back to apex — both must agree or the redirect/canonical mismatch returns.
+
 ## 2026-07-13 - SEO + accessibility pass (canonical fix, single h1, sr-only headings, breadcrumb)
 
 - **2026-07-13** · **Fixed the `/design-system/*` canonical-to-homepage bug and added a11y/SEO heading semantics + breadcrumb discoverability (one PR).** External SEO audit findings, each verified against code before acting.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Single-page Next.js 16 portfolio deployed to Vercel Edge. RSC-first composition of ~18 sections with four client islands, a streaming LLM endpoint, a durable contact form, and a CI pipeline that enforces performance, accessibility, and bundle size as hard contracts.
 
-**Live:** [erikunha.dev](https://erikunha.dev)
+**Live:** [erikunha.dev](https://www.erikunha.dev)
 
 <p>
   <img alt="Next.js 16" src="https://img.shields.io/badge/Next.js-16-000?logo=nextdotjs&logoColor=white" />

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -302,9 +302,13 @@ squash-merges, so no per-commit SHA survives on `main` and pre-merge SHAs churn
 on every rebase — the PR number is the stable, auditable reference to the single
 squash commit the decision ships in. (Historical entries that predate this
 convention keep their commit-SHA citations.) There is one canonical
-production domain — `erikunha.dev` — used consistently across every
-current-state file; historical dated ADR text and superseded specs keep their
-original wording (they record history, and history is not edited). Superseded
+production host — `www.erikunha.dev` — used consistently for every
+scheme-prefixed self-referential URL (`metadataBase`, `robots.txt` `Sitemap`,
+`sitemap.ts` `base`, `og:url`, canonical, JSON-LD) because the apex
+308-redirects to it; the bare string `erikunha.dev` remains the brand/identity
+label (OG `siteName`, the page-`<title>` suffix, the MCP server `name`,
+`@erikunha.dev` emails). Historical dated ADR text and superseded specs keep
+their original wording (they record history, and history is not edited). Superseded
 documents carry a header banner pointing at what replaced them.
 
 **Rationale.** Documentation that drifts from code is worse than no
@@ -313,9 +317,9 @@ artifact cannot ship an `ARCHITECTURE.md` that describes a system that no longer
 exists. PR-anchored ADRs make a decision auditable and a revert precise — the
 squash commit is one `git revert` away, and the PR number never goes stale under
 rebase or squash-merge the way a per-commit SHA does. One
-canonical domain removes the `erikunha.com.br` / `erikunha.dev` ambiguity the
+canonical host removes the `erikunha.com.br` / `erikunha.dev` ambiguity the
 audit flagged (`robots.txt`, `sitemap.ts`, and `layout.tsx` `metadataBase` all
-ship `.dev`).
+ship `www.erikunha.dev`, matching the apex → www redirect).
 
 **How it is held.** PR review against this chapter is the primary mechanism: the
 reviewer checks that doc claims still match code and that any new ADR cites its

--- a/__tests__/agent-surfaces.test.ts
+++ b/__tests__/agent-surfaces.test.ts
@@ -46,7 +46,7 @@ describe('public/.well-known/agent.json', () => {
       mcp?: { transport?: string; url?: string };
     };
     expect(manifest.mcp?.transport).toBe('streamable-http');
-    expect(manifest.mcp?.url).toBe('https://erikunha.dev/api/mcp');
+    expect(manifest.mcp?.url).toBe('https://www.erikunha.dev/api/mcp');
   });
 });
 

--- a/__tests__/browser-rum.test.ts
+++ b/__tests__/browser-rum.test.ts
@@ -70,7 +70,7 @@ describe('browser RUM (Vercel Analytics + Speed Insights)', () => {
   it('proxy CSP connect-src allows the two Vercel ingest origins', async () => {
     vi.resetModules();
     const { proxy } = await import('@/proxy');
-    const res = proxy(new NextRequest('https://erikunha.dev/', { method: 'GET' }));
+    const res = proxy(new NextRequest('https://www.erikunha.dev/', { method: 'GET' }));
     const csp = res.headers.get('content-security-policy') ?? '';
     const connectSrc = csp.split(';').find((d) => d.trim().startsWith('connect-src')) ?? '';
     expect(connectSrc).toContain('https://vitals.vercel-insights.com');

--- a/__tests__/og-metadata.test.ts
+++ b/__tests__/og-metadata.test.ts
@@ -7,7 +7,7 @@ vi.mock('next/font/local', () => ({
 describe('layout metadata og:image', () => {
   it('metadataBase is set to the canonical origin', async () => {
     const { metadata } = await import('@/app/layout');
-    expect(metadata.metadataBase?.toString()).toBe('https://erikunha.dev/');
+    expect(metadata.metadataBase?.toString()).toBe('https://www.erikunha.dev/');
   });
 
   it('page title matches the LinkedIn headline branding', async () => {

--- a/__tests__/proxy-csp.test.ts
+++ b/__tests__/proxy-csp.test.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const makeRequest = (): NextRequest => new NextRequest('https://erikunha.dev/', { method: 'GET' });
+const makeRequest = (): NextRequest =>
+  new NextRequest('https://www.erikunha.dev/', { method: 'GET' });
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -86,7 +87,7 @@ describe('proxy CSP — nonce-less posture', () => {
     expect(csp).toContain('report-uri /api/csp-report');
     expect(csp).toContain('report-to csp-endpoint');
     expect(res.headers.get('reporting-endpoints')).toContain(
-      'csp-endpoint="https://erikunha.dev/api/csp-report"',
+      'csp-endpoint="https://www.erikunha.dev/api/csp-report"',
     );
   });
 });

--- a/__tests__/sitemap.test.ts
+++ b/__tests__/sitemap.test.ts
@@ -19,7 +19,7 @@ describe('sitemap()', () => {
   it('includes the home URL entry', async () => {
     const { default: sitemap } = await import('@/app/sitemap');
     const entries = sitemap();
-    const home = entries.find((e) => e.url === 'https://erikunha.dev');
+    const home = entries.find((e) => e.url === 'https://www.erikunha.dev');
     expect(home).toBeDefined();
     expect(home?.priority).toBe(1);
   });
@@ -35,7 +35,7 @@ describe('sitemap()', () => {
     vi.stubEnv('CONTENT_UPDATED_AT', '2026-03-15');
     const { default: sitemap } = await import('@/app/sitemap');
     const entries = sitemap();
-    const home = entries.find((e) => e.url === 'https://erikunha.dev');
+    const home = entries.find((e) => e.url === 'https://www.erikunha.dev');
     expect(home?.lastModified).toEqual(new Date('2026-03-15'));
   });
 
@@ -43,7 +43,7 @@ describe('sitemap()', () => {
     vi.stubEnv('CONTENT_UPDATED_AT', '');
     const { default: sitemap } = await import('@/app/sitemap');
     const entries = sitemap();
-    const home = entries.find((e) => e.url === 'https://erikunha.dev');
+    const home = entries.find((e) => e.url === 'https://www.erikunha.dev');
     expect(home?.lastModified).toEqual(new Date('2026-05-22'));
   });
 });

--- a/app/design-system/_components/Breadcrumb.test.tsx
+++ b/app/design-system/_components/Breadcrumb.test.tsx
@@ -38,6 +38,6 @@ describe('Breadcrumb', () => {
     const data = JSON.parse(script?.textContent ?? '{}');
     expect(data['@type']).toBe('BreadcrumbList');
     expect(data.itemListElement).toHaveLength(3);
-    expect(data.itemListElement[2].item).toBe('https://erikunha.dev/design-system/tokens');
+    expect(data.itemListElement[2].item).toBe('https://www.erikunha.dev/design-system/tokens');
   });
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ const display = localFont({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://erikunha.dev'),
+  metadataBase: new URL('https://www.erikunha.dev'),
   title: 'Erik Cunha — Senior Full-Stack Engineer · Frontend Architecture & AI',
   description:
     'Senior Full-Stack Engineer — React, Next.js, Angular, TypeScript, Node.js. Frontend architecture, platform & applied-AI engineering for high-traffic apps.',
@@ -46,7 +46,7 @@ export const metadata: Metadata = {
     'E-commerce',
     'B2B SaaS',
   ],
-  authors: [{ name: 'Erik Henrique Alves Cunha', url: 'https://erikunha.dev' }],
+  authors: [{ name: 'Erik Henrique Alves Cunha', url: 'https://www.erikunha.dev' }],
   creator: 'Erik Henrique Alves Cunha',
   icons: {
     icon: [
@@ -63,7 +63,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: 'https://erikunha.dev',
+    url: 'https://www.erikunha.dev',
     title: 'Erik Cunha — Senior Full-Stack Engineer · Frontend Architecture & AI',
     description:
       'Senior Full-Stack Engineer · Frontend Architecture · Platform & AI Applied Engineering · React · Next.js · Angular · TypeScript · Node.js · AWS',
@@ -90,7 +90,7 @@ export const metadata: Metadata = {
     googleBot: { index: true, follow: true, 'max-image-preview': 'large' },
   },
   alternates: {
-    canonical: 'https://erikunha.dev',
+    canonical: 'https://www.erikunha.dev',
   },
 };
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const base = 'https://erikunha.dev';
+  const base = 'https://www.erikunha.dev';
   const dsDate = new Date('2026-05-23');
 
   return [

--- a/components/sections/Footer/Footer.client.tsx
+++ b/components/sections/Footer/Footer.client.tsx
@@ -260,7 +260,7 @@ export function Footer() {
                   ESTABLISHED
                 </span>
                 <a
-                  href="https://erikunha.dev"
+                  href="https://www.erikunha.dev"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="netstat-link flex items-center min-h-8 max-[768px]:overflow-hidden max-[768px]:text-ellipsis max-[768px]:whitespace-nowrap"
@@ -299,7 +299,7 @@ export function Footer() {
                   {
                     state: 'ESTABLISHED',
                     cls: 'text-primary-500 font-bold',
-                    href: 'https://erikunha.dev',
+                    href: 'https://www.erikunha.dev',
                     label: 'erikunha.dev',
                     external: true,
                   },

--- a/components/sections/Footer/Footer.designsystem-link.test.tsx
+++ b/components/sections/Footer/Footer.designsystem-link.test.tsx
@@ -60,4 +60,18 @@ describe('Footer design-system link', () => {
       expect(a.getAttribute('target')).not.toBe('_blank');
     }
   });
+
+  it.each([
+    ['desktop', false],
+    ['mobile', true],
+  ])('self-links to the site use the canonical www host, never the apex that 308-redirects on %s', (_variant, initialIsMobile) => {
+    stubMatchMedia(initialIsMobile);
+    const { container } = render(
+      <BreakpointProvider initialIsMobile={initialIsMobile}>
+        <Footer />
+      </BreakpointProvider>,
+    );
+    expect(container.querySelector('a[href="https://erikunha.dev"]')).toBeNull();
+    expect(container.querySelector('a[href="https://www.erikunha.dev"]')).not.toBeNull();
+  });
 });

--- a/content/seo.breadcrumb.test.ts
+++ b/content/seo.breadcrumb.test.ts
@@ -13,8 +13,8 @@ describe('breadcrumbSchema', () => {
     };
     expect(s['@type']).toBe('BreadcrumbList');
     expect(s.itemListElement.map((e) => e.position)).toEqual([1, 2, 3]);
-    expect(s.itemListElement[2]?.item).toBe('https://erikunha.dev/design-system/tokens');
-    expect(s.itemListElement[0]?.item).toBe('https://erikunha.dev/');
-    for (const e of s.itemListElement) expect(e.item).toMatch(/^https:\/\/erikunha\.dev/);
+    expect(s.itemListElement[2]?.item).toBe('https://www.erikunha.dev/design-system/tokens');
+    expect(s.itemListElement[0]?.item).toBe('https://www.erikunha.dev/');
+    for (const e of s.itemListElement) expect(e.item).toMatch(/^https:\/\/www\.erikunha\.dev/);
   });
 });

--- a/content/seo.ts
+++ b/content/seo.ts
@@ -6,7 +6,7 @@ export const personSchema = {
   name: 'Erik Henrique Alves Cunha',
   alternateName: 'Erik Cunha',
   jobTitle: 'Senior Full-Stack Engineer · Frontend Architecture & AI',
-  url: 'https://erikunha.dev',
+  url: 'https://www.erikunha.dev',
   email: 'erikhenriquealvescunha@gmail.com',
   telephone: '+5519997049125',
   knowsLanguage: [
@@ -165,7 +165,7 @@ z.object({
   email: z.string().email(),
 }).parse(personSchema);
 
-const SITE_ORIGIN = 'https://erikunha.dev';
+const SITE_ORIGIN = 'https://www.erikunha.dev';
 
 export function breadcrumbSchema(trail: { name: string; path: string }[]) {
   return {

--- a/content/social.ts
+++ b/content/social.ts
@@ -4,7 +4,7 @@ export const social: Social = SocialSchema.parse({
   github: 'https://github.com/erikunha',
   linkedin: 'https://www.linkedin.com/in/erikunha/',
   email: 'erikhenriquealvescunha@gmail.com',
-  site: 'https://erikunha.dev',
+  site: 'https://www.erikunha.dev',
   handle: 'erikunha',
   whatsapp: 'https://wa.me/5519997049125',
 });

--- a/lib/agent/mcp-tools.ts
+++ b/lib/agent/mcp-tools.ts
@@ -9,7 +9,7 @@ function textResult(text: string) {
 }
 
 async function runAsk(question: string): Promise<string> {
-  const req = new Request('https://erikunha.dev/api/ask', {
+  const req = new Request('https://www.erikunha.dev/api/ask', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ question }),

--- a/lib/hiring-profile.ts
+++ b/lib/hiring-profile.ts
@@ -52,7 +52,7 @@ export const HIRING_PROFILE: HiringProfile = HiringProfileSchema.parse({
   '@type': 'HiringProfile',
   name: 'Erik Henrique Alves Cunha',
   alias: 'Erik Cunha',
-  url: 'https://erikunha.dev',
+  url: 'https://www.erikunha.dev',
   email: 'erikhenriquealvescunha@gmail.com',
   github: 'https://github.com/erikunha',
   linkedin: 'https://www.linkedin.com/in/erikunha/',

--- a/public/.well-known/agent.json
+++ b/public/.well-known/agent.json
@@ -3,17 +3,17 @@
   "schemaVersion": "2026-05-21",
   "name": "Erik Cunha — portfolio agent surface",
   "description": "Machine-readable capability manifest for erikunha.dev, the portfolio of Erik Cunha (Staff/Principal Frontend + applied-AI engineer). Lists the endpoints an AI agent can use to read his hiring profile and ask questions about his experience.",
-  "url": "https://erikunha.dev",
+  "url": "https://www.erikunha.dev",
   "provider": {
     "name": "Erik Henrique Alves Cunha",
-    "url": "https://erikunha.dev",
+    "url": "https://www.erikunha.dev",
     "contact": "erikhenriquealvescunha@gmail.com"
   },
   "endpoints": [
     {
       "name": "ask",
       "description": "Ask a question about Erik's experience, stack, or availability. Answered by Claude Haiku 4.5 grounded only in the site's CV context.",
-      "url": "https://erikunha.dev/api/ask",
+      "url": "https://www.erikunha.dev/api/ask",
       "method": "POST",
       "input": {
         "contentType": "application/json",
@@ -45,20 +45,20 @@
     {
       "name": "erik.json",
       "description": "Structured HiringProfile document — employers, stack, receipts, work authorization, availability.",
-      "url": "https://erikunha.dev/api/erik.json",
+      "url": "https://www.erikunha.dev/api/erik.json",
       "contentType": "application/json"
     },
     {
       "name": "llms.txt",
       "description": "Plain-text profile summary for LLM crawlers.",
-      "url": "https://erikunha.dev/llms.txt",
+      "url": "https://www.erikunha.dev/llms.txt",
       "contentType": "text/plain"
     }
   ],
   "mcp": {
     "name": "erikunha.dev MCP server",
     "description": "Read-only Model Context Protocol server. Exposes get_profile (returns the HiringProfile) and ask_erik (proxies a question through /api/ask).",
-    "url": "https://erikunha.dev/api/mcp",
+    "url": "https://www.erikunha.dev/api/mcp",
     "transport": "streamable-http",
     "tools": ["get_profile", "ask_erik"]
   }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -128,11 +128,11 @@ Performance & A11y: Core Web Vitals · WCAG 2.1 AA · ARIA · Lighthouse CI
 
 ## Links
 
-- [Portfolio](https://erikunha.dev): Live site with streaming AI terminal,
+- [Portfolio](https://www.erikunha.dev): Live site with streaming AI terminal,
   performance receipts, and full project showcase
 - [GitHub](https://github.com/erikunha): Open source projects
 - [LinkedIn](https://linkedin.com/in/erikunha): Full professional history
-- [Hiring profile API](https://erikunha.dev/api/erik.json): Machine-readable
+- [Hiring profile API](https://www.erikunha.dev/api/erik.json): Machine-readable
   hiring profile (JSON)
 
 ## Design System

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -28,4 +28,4 @@ Allow: /
 User-agent: cohere-ai
 Allow: /
 
-Sitemap: https://erikunha.dev/sitemap.xml
+Sitemap: https://www.erikunha.dev/sitemap.xml


### PR DESCRIPTION
## Summary

- The apex `erikunha.dev` 308-redirects to `www.erikunha.dev` (Vercel primary domain), but every canonical / `og:url` / sitemap / JSON-LD still pointed at the apex — a canonical URL that itself redirects, partly undoing #198's dedup fix (search engines see the preferred host disagree with the serving host).
- Migrated every scheme-prefixed self-referential URL on a served/crawled surface to `https://www.erikunha.dev`: `metadataBase`, root `openGraph.url`/`alternates.canonical`/authors, `personSchema.url` + breadcrumb `SITE_ORIGIN`, `social.ts`, `hiring-profile`, the `mcp-tools` internal `Request`, the two Footer self-link `href`s, the README "Live" badge, `robots.txt`/`llms.txt`/`agent.json`, and the gate tests asserting them.
- Brand/identity strings stay bare `erikunha.dev` (OG `siteName`, page-`<title>` suffix, MCP server `name`, `@erikunha.dev` emails) — display labels, not hosts. Operational `curl .../api/healthz` runbook lines intentionally keep the apex (transparent 308, not a canonical surface).

## Type of change

- [x] `fix` — bug fix

## Test plan

- [x] `pnpm ci:local` passes (167 files, 1268 tests + 2 skipped)
- [x] New behaviour covered by tests — added a Footer gate (`Footer.designsystem-link.test.tsx`) asserting self-links use the www host and no apex `a[href]` survives, at both desktop and mobile variants; existing metadata/sitemap/breadcrumb/agent-surface tests updated to the www host.

## Visual changes

- [x] No visual regressions introduced — only `href` attribute values and docs changed; the Footer's visible link text (`erikunha.dev`) is unchanged, so no `visual.spec.ts` baseline is affected.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary)
- [x] No `use client` added without necessity (RSC drift) — no new client boundary
- [x] Bundle size impact assessed — string-literal host swaps only; zero client-JS delta
- [x] A11y impact considered — link text unchanged, no ARIA/role/focus change
- [x] ADR added to `DECISIONS.md` (2026-07-13, canonical host apex → www, with reversibility note)
