### PR TITLE
docs(governance): add CONTRIBUTING, SECURITY, CODE_OF_CONDUCT; improve PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,17 +17,19 @@
 
 ## Test plan
 
-<!-- How was this verified? Include command output or screenshots. -->
+<!-- Show the work. Paste the command output, link the CI run / Vercel preview, attach
+     screenshots. Assertions without evidence will be questioned. -->
 
 - [ ] `pnpm ci:local` passes
 - [ ] New behaviour covered by tests
+- [ ] Evidence attached where it applies (output / screenshots / before→after / benchmark)
 
 ## Visual changes
 
-<!-- Delete if no UI changes. -->
+<!-- Delete if no UI changes. Attach BEFORE / AFTER screenshots or a short recording. -->
 
-- [ ] Desktop (1280×720) checked via Playwright MCP
-- [ ] Mobile (375×812) checked via Playwright MCP
+- [ ] Before / after screenshots (or recording) attached
+- [ ] Desktop (1280×720) + Mobile (375×812) checked via Playwright MCP
 - [ ] Visual-regression baselines regenerated (if any captured section changed)
 - [ ] No visual regressions introduced
 
@@ -37,6 +39,7 @@
 - [ ] No `use client` added without necessity (RSC drift)
 - [ ] Bundle size impact assessed (`pnpm bundle-check`)
 - [ ] A11y impact considered (axe-core will gate in CI)
+- [ ] If performance-affecting: bundle-size delta + Lighthouse/CWV before→after noted
 - [ ] Security impact considered (no secrets, input validated, rate limits intact)
 - [ ] Reversible — a rollback path exists (revert SHA, or an ADR reversibility note)
 - [ ] ADR added to `DECISIONS.md` if this changes architecture

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 ## Summary
 
-<!-- What changed and why. 2-3 bullets. -->
+<!-- What changed and why. 2-3 bullets — give the reviewer the context, don't just restate the title. -->
+<!-- Link issues this resolves, e.g. "Closes #123" / "Fixes #123". Omit if none. -->
 
 -
 -
@@ -12,6 +13,7 @@
 - [ ] `refactor` — no behaviour change
 - [ ] `perf` — performance improvement
 - [ ] `chore` / `ci` / `docs` — non-functional
+- [ ] ⚠️ **breaking change** — describe the impact, migration, and rollback in Summary
 
 ## Test plan
 
@@ -26,6 +28,7 @@
 
 - [ ] Desktop (1280×720) checked via Playwright MCP
 - [ ] Mobile (375×812) checked via Playwright MCP
+- [ ] Visual-regression baselines regenerated (if any captured section changed)
 - [ ] No visual regressions introduced
 
 ## Checklist
@@ -34,4 +37,6 @@
 - [ ] No `use client` added without necessity (RSC drift)
 - [ ] Bundle size impact assessed (`pnpm bundle-check`)
 - [ ] A11y impact considered (axe-core will gate in CI)
+- [ ] Security impact considered (no secrets, input validated, rate limits intact)
+- [ ] Reversible — a rollback path exists (revert SHA, or an ADR reversibility note)
 - [ ] ADR added to `DECISIONS.md` if this changes architecture

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+erikhenriquealvescunha@gmail.com.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,9 @@ Performance, accessibility (WCAG 2.1 AA), and security are treated as implicit o
 1. Keep PRs small. Review quality drops sharply past a few hundred changed lines; the repo has a `pnpm pr-size` helper that flags when a branch should be split.
 2. Run `pnpm ci:local` (and `pnpm gates:runtime` for anything that affects the built site).
 3. Fill in **every** section of the PR template — do not write a body from scratch. `pnpm validate-pr-body <pr>` verifies the sections are filled.
-4. A visual change requires regenerated visual-regression baselines before the PR is opened.
-5. CI must be green and the automated review must approve before merge. Address all blocking review findings.
+4. **Show your work.** A PR should evidence what it claims, not just assert it: paste command output, attach before/after screenshots or a recording for UI changes, note bundle-size and Core Web Vitals deltas for performance work, and link the CI run or Vercel preview. Reviewers should be able to validate without pulling the branch.
+5. A visual change requires regenerated visual-regression baselines before the PR is opened.
+6. CI must be green and the automated review must approve before merge. Address all blocking review findings.
 
 ## Reporting bugs and requesting features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Thanks for your interest. This repository is a personal portfolio and a **reference system**: every architectural decision, performance budget, accessibility guarantee, CI gate, and lint rule is meant to hold up as something another team could adopt. Contributions are welcome, and the same bar applies to all of them.
+
+By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Prerequisites
+
+- **Node** >= 22 (`.nvmrc` pins the exact version; `nvm use`)
+- **pnpm** >= 10 (this repo is pnpm-only; do not use npm or yarn)
+- **gitleaks** on your PATH for the pre-commit secret scan (`brew install gitleaks`)
+
+```bash
+pnpm install
+pnpm dev          # http://localhost:3000
+```
+
+## Project shape
+
+- **Next.js 16 App Router · React 19 · TypeScript (strict) · Tailwind v4 · Biome**
+- Default rendering is **React Server Components / SSG** — client code is the exception and every client file is named `*.client.tsx`.
+- Content lives in `content/*.ts` as typed modules validated by Zod at build time. **Never inline user-facing copy in `.tsx`** — put it in `content/`.
+- Design tokens are CSS custom properties in `app/css/theme.css`. No raw hex outside that file.
+
+See `ARCHITECTURE.md` for the system design, `STANDARDS.md` for the engineering bar (each chapter names its enforcement gate), and `DECISIONS.md` for the running ADR log.
+
+## Branch and commit conventions
+
+- **Branch names:** `<type>/<description>` — e.g. `feat/contact-form`, `fix/hero-lcp`, `docs/readme`. Valid types: `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `style`, `revert`, `dependabot`, `design-system`. Enforced by the pre-push hook.
+- **Commits:** Conventional Commits with a required scope — `type(scope): description`. The scope is the feature area (`hero`, `contact`, `ci`, `design-system`, …), not a technical category. Enforced by commitlint (the subject line is capped at 100 chars).
+- **Stage narrowly:** `git add <files>` or `git add -u`. Do not `git add .` / `-A`.
+
+## Local gates (run before you push)
+
+Git hooks run automatically, but you can (and should) run the checks yourself:
+
+| Command | What it checks |
+|---|---|
+| `pnpm check` | Biome lint + format |
+| `pnpm typecheck` | TypeScript strict |
+| `pnpm validate-content` | Zod content schemas |
+| `pnpm test` | Vitest unit tests |
+| `pnpm test:e2e` | Playwright: a11y scan, contact/ask journeys, visual regression |
+| `pnpm ci:local` | The full local CI chain (lint + type + content + tests + gates) |
+| `pnpm bundle-check` | Bundle-size gate |
+| `pnpm lhci` | Lighthouse CI |
+
+**Pre-commit** runs Biome, a staged `gitleaks` secret scan, and commitlint. **Pre-push** runs the full verify chain and enforces the branch-name format.
+
+Performance, accessibility (WCAG 2.1 AA), and security are treated as implicit on every change, not separate phases. The performance budgets and the Lighthouse thresholds in `CLAUDE.md` are CI-enforced. **Do not disable a gate to merge** — if a gate fails, fix the underlying issue, or open an issue explaining why the gate is wrong.
+
+## Opening a pull request
+
+1. Keep PRs small. Review quality drops sharply past a few hundred changed lines; the repo has a `pnpm pr-size` helper that flags when a branch should be split.
+2. Run `pnpm ci:local` (and `pnpm gates:runtime` for anything that affects the built site).
+3. Fill in **every** section of the PR template — do not write a body from scratch. `pnpm validate-pr-body <pr>` verifies the sections are filled.
+4. A visual change requires regenerated visual-regression baselines before the PR is opened.
+5. CI must be green and the automated review must approve before merge. Address all blocking review findings.
+
+## Reporting bugs and requesting features
+
+Open a GitHub issue with a clear title, what you expected, what happened, and steps to reproduce (a link or screenshot helps). For anything security-related, follow [SECURITY.md](./SECURITY.md) instead of opening a public issue.
+
+## License and ownership
+
+This is a personal project. Opening a PR does not transfer ownership; substantial changes may be adapted or declined at the maintainer's discretion. If in doubt about whether a change is in scope, open an issue first.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+This is a single, continuously deployed web application. Only the current `main` branch (live at erikunha.dev) is supported; there are no released versions or backports.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately by either:
+
+- **GitHub Security Advisories** — open a private advisory via the repository's **Security → Report a vulnerability** tab (preferred), or
+- **Email** — erikhenriquealvescunha@gmail.com with `SECURITY` in the subject.
+
+Please include a description of the issue, the affected URL or code path, reproduction steps or a proof of concept, and the impact you believe it has. If you have a suggested fix, include it.
+
+**What to expect:** an acknowledgement within a few days, an assessment of severity, and a fix or mitigation for confirmed issues as quickly as is practical for a solo-maintained project. You will be credited in the fix unless you prefer to remain anonymous. Please give a reasonable window for a fix before any public disclosure.
+
+## Scope
+
+In scope: the deployed site and its API routes (`/api/*`), the build and CI configuration, and the dependency supply chain.
+
+Out of scope: findings that require a compromised maintainer machine or account, denial of service through raw request volume, best-practice suggestions with no demonstrated impact, and reports generated solely by automated scanners without a working proof of concept.
+
+## Security posture
+
+The repository defends in depth, and most of these are enforced in CI on every change:
+
+- **Secret scanning** — a checksum-pinned `gitleaks` runs as a pre-commit hook and in CI; a fixture test proves the scanner actually fires.
+- **Static analysis** — Semgrep and GitHub CodeQL run in CI.
+- **Dependency review** — a dependency-review gate runs on pull requests; dependencies are exact- or caret-pinned and installed with a frozen lockfile in CI.
+- **Content Security Policy** and security headers are set at the edge; the API boundary enforces rate limiting and input validation (Zod) before any handler logic runs.
+- **No secrets in the repo.** All credentials are environment variables provided at deploy time.
+
+Responsible reports that improve any of the above are genuinely appreciated.


### PR DESCRIPTION
## Summary

- Adds the open-source governance set a public reference repo should carry: `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), all derived from the repo's actual workflow and impersonal/agent-agnostic.
- Improves `.github/pull_request_template.md` with research-backed additions folded into the existing five sections, so `validate-pr-body`'s heading set is unchanged.

## Type of change

- [ ] `feat` — new functionality
- [ ] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional: governance docs + PR-template improvement
- [ ] ⚠️ **breaking change** — describe the impact, migration, and rollback in Summary

## Test plan

- [x] `pnpm ci:local` gates pass (biome, doc-drift, gate-health, codex-sync verified; docs-only, no runtime surface)
- [x] New behaviour covered by tests — N/A (documentation only). Every factual claim in CONTRIBUTING.md and SECURITY.md was verified against the live repo (Node/pnpm versions, gate commands, branch/commit enforcement, `*.client.tsx`, gitleaks/Semgrep/CodeQL/dependency-review, CSP, rate-limit + Zod). `validate-pr-body` still finds the same five headings, so the PR-template gate is unbroken.

## Visual changes

No UI changes — documentation only. No baseline affected.

## Checklist

- [x] No hardcoded hex values / magic numbers — N/A (docs)
- [x] No `use client` added — no app code changed
- [x] Bundle size impact — none (no runtime code)
- [x] A11y impact — none
- [x] Security impact considered — SECURITY.md documents the existing posture only; no control overstated; contact is the already-public repo address (no new exposure)
- [x] Reversible — `git revert <sha>` removes all four files; nothing depends on them
- [x] ADR added if architecture changed — N/A

## Notes

- **SECURITY.md assumes GitHub private vulnerability reporting is enabled** (Settings → Code security → Private vulnerability reporting). The email path works regardless; enable the advisories feature to activate the preferred channel.
- The contact email is already public across the repo (`content/social.ts`, `lib/hiring-profile.ts`, the live site), so this introduces no new exposure.
- PR-template additions: linked-issue prompt (Summary), a breaking-change type, a visual-baseline-regen line, and Security + Reversibility checklist items. Sources: GitHub Docs, DeployHQ and gitmore 2026 PR-template guides.
