### PR TITLE
fix(hooks): block-logic tests + close the malformed-payload fail-open in both blocking hooks

### DIFF
--- a/.claude/hooks/__tests__/run.sh
+++ b/.claude/hooks/__tests__/run.sh
@@ -460,6 +460,12 @@ rm -rf "$d"
 
 d=$(asg_mkroot)
 printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
+(printf '{"tool_name":"Bash","tool_input":{"command":"git push origin main"},"transcript_path":' | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
+assert_eq "asg: truncated JSON payload with quoted git-push command fails closed" "2" "$?"
+rm -rf "$d"
+
+d=$(asg_mkroot)
+printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
 (printf 'garbled not json, nothing relevant here' | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
 assert_eq "asg: malformed payload with no token allowed" "0" "$?"
 rm -rf "$d"

--- a/.claude/hooks/__tests__/run.sh
+++ b/.claude/hooks/__tests__/run.sh
@@ -330,4 +330,129 @@ if [ -s "$aem_d/.claude/.api-edit-pending" ]; then aem_fc=MARKED; else aem_fc=NO
 rm -rf "$aem_d"
 assert_eq "aem: fail-closed on malformed payload with API path" "MARKED" "$aem_fc"
 
+# --- architect-gate.sh block logic (writing-plans PreToolUse Skill matcher) ---
+AG_HOOK="$HOOKS/architect-gate.sh"
+ag_payload() { # $1=skill $2=transcript-path -> JSON PreToolUse payload for the Skill matcher
+  python3 -c 'import json,sys; print(json.dumps({"tool_name":"Skill","tool_input":{"skill": sys.argv[1]}, "transcript_path": sys.argv[2]}))' "$1" "$2"
+}
+
+(cd "$REPO_ROOT" && ag_payload 'superpowers:brainstorming' "$FIXDIR/ag-nonexistent-$$.jsonl" | bash "$AG_HOOK") >/dev/null 2>&1
+assert_eq "ag: non-matching skill allowed" "0" "$?"
+
+AG_T_NONE="$FIXDIR/ag-none-$$.jsonl"
+printf '%s\n' '{"message":{"role":"assistant","content":[{"type":"text","text":"no agent dispatch here"}]}}' > "$AG_T_NONE"
+out=$(cd "$REPO_ROOT" && ag_payload 'superpowers:writing-plans' "$AG_T_NONE" | bash "$AG_HOOK" 2>&1)
+ec=$?
+assert_eq "ag: block when transcript has no architect-reviewer dispatch" "2" "$ec"
+assert_contains "ag: block message names the missing PASS" "$out" "no architect-reviewer GATE_RESULT: PASS"
+rm -f "$AG_T_NONE"
+
+AG_T_FAIL="$FIXDIR/ag-fail-$$.jsonl"
+{
+  printf '%s\n' '{"message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_ag_fail","name":"Agent","input":{"subagent_type":"architect-reviewer","prompt":"Review the spec."}}]}}'
+  printf '%s\n' '{"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_ag_fail","content":"Spec has gaps.\nGATE_RESULT: FAIL"}]}}'
+} > "$AG_T_FAIL"
+(cd "$REPO_ROOT" && ag_payload 'superpowers:writing-plans' "$AG_T_FAIL" | bash "$AG_HOOK") >/dev/null 2>&1
+assert_eq "ag: block when architect-reviewer returned GATE_RESULT: FAIL" "2" "$?"
+rm -f "$AG_T_FAIL"
+
+AG_T_WRONG_AGENT="$FIXDIR/ag-wrong-agent-$$.jsonl"
+{
+  printf '%s\n' '{"message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_ag_wrong","name":"Agent","input":{"subagent_type":"code-reviewer","prompt":"Review the code."}}]}}'
+  printf '%s\n' '{"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_ag_wrong","content":"Looks fine.\nGATE_RESULT: PASS"}]}}'
+} > "$AG_T_WRONG_AGENT"
+(cd "$REPO_ROOT" && ag_payload 'superpowers:writing-plans' "$AG_T_WRONG_AGENT" | bash "$AG_HOOK") >/dev/null 2>&1
+assert_eq "ag: block when PASS came from a non-architect-reviewer agent" "2" "$?"
+rm -f "$AG_T_WRONG_AGENT"
+
+AG_T_PASS="$FIXDIR/ag-pass-$$.jsonl"
+{
+  printf '%s\n' '{"message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_ag_pass","name":"Agent","input":{"subagent_type":"architect-reviewer","prompt":"Review the spec against the four-gate protocol."}}]}}'
+  printf '%s\n' '{"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_ag_pass","content":"Spec reviewed end to end.\nGATE_RESULT: PASS"}]}}'
+} > "$AG_T_PASS"
+(cd "$REPO_ROOT" && ag_payload 'superpowers:writing-plans' "$AG_T_PASS" | bash "$AG_HOOK") >/dev/null 2>&1
+assert_eq "ag: allow when architect-reviewer returned GATE_RESULT: PASS" "0" "$?"
+rm -f "$AG_T_PASS"
+
+out=$(cd "$REPO_ROOT" && ag_payload 'superpowers:writing-plans' "$FIXDIR/ag-missing-$$.jsonl" | bash "$AG_HOOK" 2>&1)
+ec=$?
+assert_eq "ag: fail-closed on unreadable transcript path" "2" "$ec"
+assert_contains "ag: fail-closed message cites unreadable transcript" "$out" "transcript unreadable (fail-closed)"
+
+(cd "$REPO_ROOT" && ag_payload 'superpowers:writing-plans' '' | bash "$AG_HOOK") >/dev/null 2>&1
+assert_eq "ag: fail-closed on empty transcript_path" "2" "$?"
+
+(printf 'superpowers:writing-plans embedded in unparseable json' | ( cd "$REPO_ROOT" && bash "$AG_HOOK" )) >/dev/null 2>&1
+assert_eq "ag: malformed payload allowed (fail-open concern, see report)" "0" "$?"
+
+# --- api-security-push-guard.sh block logic (git push PreToolUse Bash matcher) ---
+ASG_HOOK="$HOOKS/api-security-push-guard.sh"
+asg_payload() { # $1=command $2=transcript-path -> JSON PreToolUse payload for the Bash matcher
+  python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command": sys.argv[1]},"transcript_path": sys.argv[2]}))' "$1" "$2"
+}
+asg_mkroot() { # -> isolated non-git dir seeded with a transcript.mjs copy so the hook's own node parser resolves
+  local d; d=$(mktemp -d)
+  mkdir -p "$d/scripts/lib" "$d/.claude"
+  cp "$REPO_ROOT/scripts/lib/transcript.mjs" "$d/scripts/lib/transcript.mjs"
+  printf '%s' "$d"
+}
+
+d=$(asg_mkroot)
+(asg_payload 'git status' '' | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
+assert_eq "asg: non-push command allowed" "0" "$?"
+rm -rf "$d"
+
+d=$(asg_mkroot)
+(asg_payload 'git push origin main' '' | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
+assert_eq "asg: push allowed with no marker pending" "0" "$?"
+rm -rf "$d"
+
+d=$(asg_mkroot)
+printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
+ASG_T_NONE="$FIXDIR/asg-none-$$.jsonl"
+printf '%s\n' '{"timestamp":"2020-01-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"no dispatch"}]}}' > "$ASG_T_NONE"
+out=$(asg_payload 'git push origin main' "$ASG_T_NONE" | ( cd "$d" && bash "$ASG_HOOK" ) 2>&1)
+ec=$?
+assert_eq "asg: block when marker pending and no security-auditor dispatch" "2" "$ec"
+assert_contains "asg: block message cites unaudited edit" "$out" "unaudited API-surface edit"
+rm -rf "$d"; rm -f "$ASG_T_NONE"
+
+d=$(asg_mkroot)
+printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
+ASG_T_STALE="$FIXDIR/asg-stale-$$.jsonl"
+printf '%s\n' '{"timestamp":"2019-01-01T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_asg_stale","name":"Agent","input":{"subagent_type":"security-auditor","prompt":"stale audit predating the marker"}}]}}' > "$ASG_T_STALE"
+(asg_payload 'git push origin main' "$ASG_T_STALE" | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
+assert_eq "asg: block when security-auditor dispatch predates the marker" "2" "$?"
+rm -rf "$d"; rm -f "$ASG_T_STALE"
+
+d=$(asg_mkroot)
+printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
+ASG_T_PASS="$FIXDIR/asg-pass-$$.jsonl"
+printf '%s\n' '{"timestamp":"2020-01-01T00:05:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_asg_pass","name":"Agent","input":{"subagent_type":"security-auditor","prompt":"Audit the API-surface change."}}]}}' > "$ASG_T_PASS"
+(asg_payload 'git push origin main' "$ASG_T_PASS" | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
+assert_eq "asg: allow when security-auditor dispatched after the marker" "0" "$?"
+if [ -e "$d/.claude/.api-edit-pending" ]; then asg_marker_state=EXISTS; else asg_marker_state=CLEARED; fi
+assert_eq "asg: marker cleared after a verified audit" "CLEARED" "$asg_marker_state"
+rm -rf "$d"; rm -f "$ASG_T_PASS"
+
+d=$(asg_mkroot)
+printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
+out=$(asg_payload 'git push origin main' "$d/does-not-exist-$$.jsonl" | ( cd "$d" && bash "$ASG_HOOK" ) 2>&1)
+ec=$?
+assert_eq "asg: fail-closed on unreadable transcript with marker pending" "2" "$ec"
+assert_contains "asg: fail-closed message cites unreadable transcript" "$out" "transcript unreadable (fail-closed)"
+rm -rf "$d"
+
+d=$(asg_mkroot)
+printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
+(asg_payload 'git push origin main' '' | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
+assert_eq "asg: fail-closed on empty transcript_path with marker pending" "2" "$?"
+rm -rf "$d"
+
+d=$(asg_mkroot)
+printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
+(printf 'garbled not json git push origin main' | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
+assert_eq "asg: malformed payload allowed despite marker+push text (fail-open concern, see report)" "0" "$?"
+rm -rf "$d"
+
 [ "$FAILED" -eq 0 ] && { printf '\nALL PASS\n'; exit 0; } || { printf '\nFAILURES\n'; exit 1; }

--- a/.claude/hooks/__tests__/run.sh
+++ b/.claude/hooks/__tests__/run.sh
@@ -383,7 +383,10 @@ assert_contains "ag: fail-closed message cites unreadable transcript" "$out" "tr
 assert_eq "ag: fail-closed on empty transcript_path" "2" "$?"
 
 (printf 'superpowers:writing-plans embedded in unparseable json' | ( cd "$REPO_ROOT" && bash "$AG_HOOK" )) >/dev/null 2>&1
-assert_eq "ag: malformed payload allowed (fail-open concern, see report)" "0" "$?"
+assert_eq "ag: malformed payload with writing-plans token fails closed" "2" "$?"
+
+(printf 'just some garbled non-json text with no skill token' | ( cd "$REPO_ROOT" && bash "$AG_HOOK" )) >/dev/null 2>&1
+assert_eq "ag: malformed payload with no token allowed" "0" "$?"
 
 # --- api-security-push-guard.sh block logic (git push PreToolUse Bash matcher) ---
 ASG_HOOK="$HOOKS/api-security-push-guard.sh"
@@ -452,7 +455,13 @@ rm -rf "$d"
 d=$(asg_mkroot)
 printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
 (printf 'garbled not json git push origin main' | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
-assert_eq "asg: malformed payload allowed despite marker+push text (fail-open concern, see report)" "0" "$?"
+assert_eq "asg: malformed payload with git-push token fails closed" "2" "$?"
+rm -rf "$d"
+
+d=$(asg_mkroot)
+printf '2020-01-01T00:00:00.000Z\tabc123\tapp/api/route.ts\n' > "$d/.claude/.api-edit-pending"
+(printf 'garbled not json, nothing relevant here' | ( cd "$d" && bash "$ASG_HOOK" )) >/dev/null 2>&1
+assert_eq "asg: malformed payload with no token allowed" "0" "$?"
 rm -rf "$d"
 
 [ "$FAILED" -eq 0 ] && { printf '\nALL PASS\n'; exit 0; } || { printf '\nFAILURES\n'; exit 1; }

--- a/.claude/hooks/api-security-push-guard.sh
+++ b/.claude/hooks/api-security-push-guard.sh
@@ -8,9 +8,11 @@ try:
 except Exception: print('')
 " 2>/dev/null || echo "")
 # Same raw-payload fallback as bash-guard.sh: a malformed payload still
-# carrying a git-push token must not silently fail open.
+# carrying a git-push token must not silently fail open. JSON punctuation is
+# normalized to spaces because in JSON-shaped text the token sits against a
+# quote ("git), which the whitespace-boundary push regex below cannot match.
 if [ -z "$CMD" ] && [ -n "$INPUT" ]; then
-  CMD="$INPUT"
+  CMD=$(printf '%s' "$INPUT" | tr '":;&|(){}' ' ')
 fi
 TRANSCRIPT=$(printf '%s' "$INPUT" | python3 -c "
 import json,sys

--- a/.claude/hooks/api-security-push-guard.sh
+++ b/.claude/hooks/api-security-push-guard.sh
@@ -7,6 +7,11 @@ try:
   print(d.get('tool_input',{}).get('command','') or d.get('command',''))
 except Exception: print('')
 " 2>/dev/null || echo "")
+# Same raw-payload fallback as bash-guard.sh: a malformed payload still
+# carrying a git-push token must not silently fail open.
+if [ -z "$CMD" ] && [ -n "$INPUT" ]; then
+  CMD="$INPUT"
+fi
 TRANSCRIPT=$(printf '%s' "$INPUT" | python3 -c "
 import json,sys
 try: print(json.load(sys.stdin).get('transcript_path',''))

--- a/.claude/hooks/architect-gate.sh
+++ b/.claude/hooks/architect-gate.sh
@@ -7,6 +7,11 @@ try:
   print(d.get('tool_input',{}).get('skill','') or d.get('skill',''))
 except Exception: print('')
 " 2>/dev/null || echo "")
+# Same raw-payload fallback as bash-guard.sh / api-edit-marker.sh: a malformed
+# payload still carrying the token must not silently fail open.
+if [ -z "$SKILL" ] && [ -n "$INPUT" ]; then
+  printf '%s' "$INPUT" | grep -qF 'superpowers:writing-plans' && SKILL='superpowers:writing-plans'
+fi
 TRANSCRIPT=$(printf '%s' "$INPUT" | python3 -c "
 import json,sys
 try: print(json.load(sys.stdin).get('transcript_path',''))

--- a/.codex/hooks/api-security-push-guard.sh
+++ b/.codex/hooks/api-security-push-guard.sh
@@ -8,9 +8,11 @@ try:
 except Exception: print('')
 " 2>/dev/null || echo "")
 # Same raw-payload fallback as bash-guard.sh: a malformed payload still
-# carrying a git-push token must not silently fail open.
+# carrying a git-push token must not silently fail open. JSON punctuation is
+# normalized to spaces because in JSON-shaped text the token sits against a
+# quote ("git), which the whitespace-boundary push regex below cannot match.
 if [ -z "$CMD" ] && [ -n "$INPUT" ]; then
-  CMD="$INPUT"
+  CMD=$(printf '%s' "$INPUT" | tr '":;&|(){}' ' ')
 fi
 TRANSCRIPT=$(printf '%s' "$INPUT" | python3 -c "
 import json,sys

--- a/.codex/hooks/api-security-push-guard.sh
+++ b/.codex/hooks/api-security-push-guard.sh
@@ -7,6 +7,11 @@ try:
   print(d.get('tool_input',{}).get('command','') or d.get('command',''))
 except Exception: print('')
 " 2>/dev/null || echo "")
+# Same raw-payload fallback as bash-guard.sh: a malformed payload still
+# carrying a git-push token must not silently fail open.
+if [ -z "$CMD" ] && [ -n "$INPUT" ]; then
+  CMD="$INPUT"
+fi
 TRANSCRIPT=$(printf '%s' "$INPUT" | python3 -c "
 import json,sys
 try: print(json.load(sys.stdin).get('transcript_path',''))

--- a/.codex/hooks/architect-gate.sh
+++ b/.codex/hooks/architect-gate.sh
@@ -7,6 +7,11 @@ try:
   print(d.get('tool_input',{}).get('skill','') or d.get('skill',''))
 except Exception: print('')
 " 2>/dev/null || echo "")
+# Same raw-payload fallback as bash-guard.sh / api-edit-marker.sh: a malformed
+# payload still carrying the token must not silently fail open.
+if [ -z "$SKILL" ] && [ -n "$INPUT" ]; then
+  printf '%s' "$INPUT" | grep -qF 'superpowers:writing-plans' && SKILL='superpowers:writing-plans'
+fi
 TRANSCRIPT=$(printf '%s' "$INPUT" | python3 -c "
 import json,sys
 try: print(json.load(sys.stdin).get('transcript_path',''))


### PR DESCRIPTION
## Summary

- The two blocking harness hooks — `architect-gate.sh` and `api-security-push-guard.sh` — had no behavioral test of their exit-2 block logic (harness-audit finding 6 residual; the repo's own rule is "verify a guard blocks with a live test"). Added 24 assertions to `.claude/hooks/__tests__/run.sh`: block / allow / non-match / fail-closed per hook, isolated in `mktemp` sandboxes with a copied `transcript.mjs` so the hooks' corroboration parser resolves without the real repo root.
- Writing the tests exposed a real defect, fixed in the second commit: both hooks were **fail-open on a malformed JSON payload** — a parse exception yielded an empty field, read as "no match", exit 0, before any fail-closed logic ran, even when the raw payload contained the guarded token. This is the exact class the audit fixed in `bash-guard.sh`/`api-edit-marker.sh`; the pattern scan then missed these two siblings. The fix copies the siblings' raw-payload fallback verbatim; a token-bearing malformed payload now lands fail-closed (exit 2), a token-free one stays allowed.
- Security review confirmed the closure is complete (no constructible malformed payload reaches exit 0 while carrying the guarded token, including the python3-missing path) and noted the push-guard is the most load-bearing hook of the set — its guarded property has no server-side backstop. One pre-existing Minor recorded as a follow-up in the findings ledger: the push-guard's word-boundary grep can false-block a commit message containing `git`/`push` tokens (over-block direction; candidate fix is routing through the vendored bashlex like `bash-guard`).

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new functionality
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [ ] `chore` / `ci` / `docs` — non-functional
- [ ] ⚠️ **breaking change** — describe the impact, migration, and rollback in Summary

## Test plan

- [x] `pnpm ci:local` passes via `pnpm ready-for-pr` (see log excerpt in checks); `pnpm test:hooks` 161 ok / ALL PASS; `check:codex-sync` OK; biome clean
- [x] New behaviour covered by tests — 24 new run.sh assertions; every primary block case mutation-verified by hand (inverting the unlock condition flips the exit code away from 2; stripping either raw-payload fallback flips its fail-closed assertion from 2 to 0)
- [x] Evidence attached — mutation evidence per case in the commit bodies; test isolation verified empirically (no `.api-edit-pending` leakage, clean `git status` post-run)

## Visual changes

None — hook scripts, a bash test harness, and their generated mirror copies; nothing renders.

## Checklist

- [x] No hardcoded hex values / magic numbers (token boundary) — bash test harness is literal-exempt like all test files; hook change reuses existing named vars
- [x] No `use client` added without necessity (RSC drift) — no component code touched
- [x] Bundle size impact assessed — zero: no `app/`/`components/`/`lib/` path in the diff
- [x] A11y impact considered — no rendered surface
- [x] If performance-affecting: not performance-affecting — the fallback adds one in-memory grep on the rare parse-failure path of a per-tool-call hook
- [x] Security impact considered — this PR is the security fix; adversarial review found no Critical/Important, closure verified complete, minor follow-up recorded in the ledger
- [x] Reversible — revert the two commits; the mirror regenerates from `.claude/` either way
- [x] ADR added to `DECISIONS.md` if this changes architecture — not needed: applies an established fail-closed pattern to two more hooks; reasoning in the commit bodies
