### PR TITLE
ci(claude-review): stop cancelling reviews, a duplicate beats none

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,14 +7,17 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  # One group per PR across both events, so any newer run supersedes the one in
-  # flight. Splitting by event name put a comment run and a push run in separate
-  # groups, which meant neither cancelled the other and both reviewed the same
-  # PR at once, racing to post the verdict the merge gate reads last. A review
-  # is only valid against the HEAD it read, so once HEAD moves the in-flight run
-  # is reviewing a stale commit and superseding it is the correct outcome.
+  # One group per PR across both events, so runs on a PR serialize rather than
+  # overlap. Cancellation is OFF: GitHub resolves concurrency at the RUN level,
+  # before a job's `if:` is evaluated, so an ordinary comment -- one that does
+  # not contain the trigger phrase and whose job is then skipped -- still enters
+  # this group. With cancellation on it killed the in-flight review and posted
+  # nothing in its place, leaving the PR with no verdict at all; observed on
+  # #221, where GitHub reported "Canceling since a higher priority waiting
+  # request for claude-review-221 exists". Queuing costs a duplicate review when
+  # a push lands mid-flight. No review is the worse failure, so this waits.
   group: claude-review-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- **PR #221 could not obtain a review verdict.** GitHub's own annotation names the cause: `Canceling since a higher priority waiting request for claude-review-221 exists`.
- Concurrency resolves at the **run** level, before a job's `if:` is evaluated. An ordinary comment therefore creates a run that enters the group even though its job is then skipped for lacking the trigger phrase. With `cancel-in-progress: true`, that skipped run killed the in-flight review and posted nothing in its place.
- Every comment on a PR became a review-killer, including the `/claude-review` request itself racing the previous one. Turning cancellation off restores serialized queuing.

## Type of change

- [ ] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [x] `chore` / `ci` / `docs` — non-functional
- [ ] ⚠️ **breaking change**

## Test plan

- [x] `pnpm ci:local` passes (EXIT=0)
- [x] New behaviour covered by tests
- [x] Evidence attached

Config-only, one line of behaviour. Evidence is the production failure itself:

```
review: Canceling since a higher priority waiting request for claude-review-221 exists
review: The operation was canceled.
```

#221 sat with 0 failing checks, 0 unresolved threads and every finding addressed, blocked solely on a verdict it could not obtain.

## Visual changes

None. Config-only.

## Checklist

- [x] No hardcoded hex values / magic numbers
- [x] No `use client` added
- [x] Bundle size impact assessed — n/a, no application code
- [x] A11y impact considered — n/a
- [x] Performance: costs CI minutes (superseded runs now complete instead of being killed); measured trade-off in the body below
- [x] Security impact considered — closes the starve-the-gate vector raised against unconditional cancellation
- [x] Reversible — single-line revert
- [ ] ADR added to `DECISIONS.md` — not needed, corrects a config defect introduced two PRs ago

## Known issues, justified

**This reintroduces a duplicate review when a push lands mid-flight**, which is the double-run the shared group was meant to fix. That is the right way round: a redundant verdict is noise, no verdict blocks the merge gate outright. `check-claude-approval.ts` reads the newest `claude[bot]` comment, so the last verdict to land is the one that counts.

**The durable fix is different and larger.** The trigger phrase must be evaluated **before** the group is entered, so a non-matching comment never joins it — a gate job whose output keys the concurrency group, with the review job depending on it. That is more than this branch should carry while #221 is blocked on it.

**A reviewer stated this mechanism plainly when the shared group was introduced and it was recorded as a benign trade-off.** It was not benign; it was the blocker. Noted here because the failure was predicted and dismissed, not undiscovered.

**This PR edits `claude-review.yml`, so it cannot auto-review itself** — the action refuses to run when the workflow differs from the default branch. Request `/claude-review` manually.