### PR TITLE
feat(review): stamp findings with when and against which commit

### DIFF
--- a/__tests__/scripts/review-findings.test.ts
+++ b/__tests__/scripts/review-findings.test.ts
@@ -121,8 +121,6 @@ describe('archiveRecords', () => {
 
 describe('finding provenance', () => {
   it('parses a finding recorded before provenance existed', () => {
-    // 276 findings predate these fields. Backfilling would invent data, so the
-    // schema must accept their absence or the whole ledger stops loading.
     const legacy = {
       id: 'abc123',
       severity: 'critical',
@@ -139,13 +137,10 @@ describe('finding provenance', () => {
   });
 
   it('records the sentinel, not a plausible-looking sha, when HEAD cannot be resolved', () => {
-    const cwd = process.cwd();
     const outside = mkdtempSync(join(tmpdir(), 'no-git-'));
     try {
-      process.chdir(outside);
-      expect(headSha()).toBe(UNRESOLVED_HEAD);
+      expect(headSha(outside)).toBe(UNRESOLVED_HEAD);
     } finally {
-      process.chdir(cwd);
       rmSync(outside, { recursive: true, force: true });
     }
   });

--- a/__tests__/scripts/review-findings.test.ts
+++ b/__tests__/scripts/review-findings.test.ts
@@ -1,10 +1,16 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   archiveRecords,
   blockingFindings,
   type Finding,
+  FindingSchema,
   findingId,
+  headSha,
   invalidResolutions,
+  UNRESOLVED_HEAD,
   withFinding,
   withStatus,
 } from '@/scripts/review-findings';
@@ -110,5 +116,37 @@ describe('archiveRecords', () => {
 
   it('terminates with a trailing newline so appends stay line-delimited', () => {
     expect(archiveRecords([f({})], 'sha', 'iso').endsWith('\n')).toBe(true);
+  });
+});
+
+describe('finding provenance', () => {
+  it('parses a finding recorded before provenance existed', () => {
+    // 276 findings predate these fields. Backfilling would invent data, so the
+    // schema must accept their absence or the whole ledger stops loading.
+    const legacy = {
+      id: 'abc123',
+      severity: 'critical',
+      title: 'recorded before recordedAt existed',
+      source: 'code-reviewer',
+      status: 'open',
+    };
+    expect(() => FindingSchema.parse(legacy)).not.toThrow();
+    expect(FindingSchema.parse(legacy).recordedAt).toBeUndefined();
+  });
+
+  it('resolves a real short sha inside this repo', () => {
+    expect(headSha()).toMatch(/^[0-9a-f]{7,}$/);
+  });
+
+  it('records the sentinel, not a plausible-looking sha, when HEAD cannot be resolved', () => {
+    const cwd = process.cwd();
+    const outside = mkdtempSync(join(tmpdir(), 'no-git-'));
+    try {
+      process.chdir(outside);
+      expect(headSha()).toBe(UNRESOLVED_HEAD);
+    } finally {
+      process.chdir(cwd);
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/review-findings.ts
+++ b/scripts/review-findings.ts
@@ -25,9 +25,9 @@ export const LEDGER_PATH = '.review-findings.json';
 
 export const UNRESOLVED_HEAD = 'unresolved';
 
-export function headSha(): string {
+export function headSha(cwd: string = process.cwd()): string {
   try {
-    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf8', cwd }).trim();
   } catch (error) {
     console.error(
       `[review-findings] could not resolve HEAD, recording "${UNRESOLVED_HEAD}": ${error}`,

--- a/scripts/review-findings.ts
+++ b/scripts/review-findings.ts
@@ -15,9 +15,6 @@ export const FindingSchema = z.object({
   source: z.string().min(1),
   status: z.enum(['open', 'resolved', 'justified']),
   resolution: z.string().optional(),
-  // Provenance. Without it the ledger cannot say which review round produced a
-  // finding, so "does round N still pay for itself" stays a matter of opinion.
-  // Optional because the findings that predate this would have to be invented.
   recordedAt: z.string().optional(),
   recordedAtHead: z.string().optional(),
 });
@@ -26,13 +23,16 @@ export const LedgerSchema = z.array(FindingSchema);
 
 export const LEDGER_PATH = '.review-findings.json';
 
-// A round is delimited by the commit it reviewed, so HEAD at record time is what
-// makes per-round counts derivable later.
+export const UNRESOLVED_HEAD = 'unresolved';
+
 export function headSha(): string {
   try {
     return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
-  } catch {
-    return 'unknown';
+  } catch (error) {
+    console.error(
+      `[review-findings] could not resolve HEAD, recording "${UNRESOLVED_HEAD}": ${error}`,
+    );
+    return UNRESOLVED_HEAD;
   }
 }
 

--- a/scripts/review-findings.ts
+++ b/scripts/review-findings.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
 
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -14,11 +15,26 @@ export const FindingSchema = z.object({
   source: z.string().min(1),
   status: z.enum(['open', 'resolved', 'justified']),
   resolution: z.string().optional(),
+  // Provenance. Without it the ledger cannot say which review round produced a
+  // finding, so "does round N still pay for itself" stays a matter of opinion.
+  // Optional because the findings that predate this would have to be invented.
+  recordedAt: z.string().optional(),
+  recordedAtHead: z.string().optional(),
 });
 export type Finding = z.infer<typeof FindingSchema>;
 export const LedgerSchema = z.array(FindingSchema);
 
 export const LEDGER_PATH = '.review-findings.json';
+
+// A round is delimited by the commit it reviewed, so HEAD at record time is what
+// makes per-round counts derivable later.
+export function headSha(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
 
 export function blockingFindings(findings: Finding[]): Finding[] {
   return findings.filter(
@@ -94,6 +110,8 @@ function main(argv: string[]): void {
         source,
         title,
         status: 'open',
+        recordedAt: new Date().toISOString(),
+        recordedAtHead: headSha(),
       });
       writeLedger(withFinding(ledger, finding));
       console.log(`[review-findings] recorded ${finding.severity} ${finding.id}: ${finding.title}`);


### PR DESCRIPTION
## Summary

- **The findings ledger could not answer the question it exists to inform.** 276 findings carry a severity, a source and a status, and no time or commit anchor at all — so "does a late battery round still find anything" has been unanswerable, and the cost of running round six stayed a matter of opinion.
- `review:findings add` now records `recordedAt` and the short HEAD at record time. Both fields are **optional** in the schema: the 276 that predate them parse unchanged, and backfilling would have meant inventing data.
- This does not answer the question. It makes the question answerable, which is the part that was missing — the same move as `capability-usage.mjs`: measure the thing before arguing about it.

## Type of change

- [x] `feat` — new functionality
- [x] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `perf` — performance improvement
- [ ] `chore` / `ci` / `docs` — non-functional
- [ ] ⚠️ **breaking change**

## Test plan

- [x] `pnpm ci:local` passes (EXIT=0)
- [x] New behaviour covered by tests
- [x] Evidence attached

Three tests added, covering the claim the first commit made without one:

```
parses a finding recorded before provenance existed        <- the 276-legacy claim
resolves a real short sha inside this repo                 <- happy path
records the sentinel, not a plausible-looking sha, when    <- failure path, real git
  HEAD cannot be resolved

pnpm vitest run __tests__/scripts/review-findings.test.ts  ->  17 passed
pnpm ci:local                                              ->  EXIT=0
```

The failure-path test passes a `mkdtemp` directory to `headSha(cwd)` rather than calling `process.chdir`, so it exercises real git failing without mutating global state.

## Visual changes

None. A CLI script and its tests.

## Checklist

- [x] No hardcoded hex values / magic numbers — the sentinel is named `UNRESOLVED_HEAD`
- [x] No `use client` added
- [x] Bundle size impact assessed — n/a, `scripts/` is not shipped
- [x] A11y impact considered — n/a
- [x] Performance: one `git rev-parse` per `add`, a handful of times per review cycle
- [x] Security impact considered — `execFileSync` with fixed argv, no shell, no user input reaches it
- [x] Reversible — both fields are optional, so a revert leaves every ledger entry valid
- [ ] ADR added to `DECISIONS.md` — not needed; adds provenance to an existing local tool

## Known issues, justified

**`recordedAtHead` alone cannot separate rounds that share a HEAD, and that is the common case.** This repo's process mandates fix-and-re-review before committing, so several batteries run against the same uncommitted tree — rounds 5 and 6 of the concurrency-gate work, the example that motivated this, would carry the identical HEAD. `recordedAt` is the discriminator at that granularity and `recordedAtHead` across commits; both are needed and neither alone is sufficient. The first commit's body implied otherwise and the second corrects it.

## Review history worth reading

Three review rounds, five findings, all of them mine, two worth naming because they are the same class this repo keeps paying for:

- I deleted two rationale comments from the source file for violating the bare-source rule, then **added a test-intent essay to the test file in the same commit**. Same rule, one file over.
- I called the `process.chdir` test safe because it restored `cwd` in a `finally`. Safe in isolation is not safe under parallel execution; passing a directory removes the window rather than narrowing it.
